### PR TITLE
Add Google OAuth login buttons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,9 @@ gem "turbo-rails"
 gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
+gem "omniauth"
+gem "omniauth-rails_csrf_protection"
+gem "omniauth-google-oauth2"
 
 gem "rspec"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,11 +111,19 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hashie (5.1.0)
+      logger
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.3)
@@ -132,6 +140,8 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     json (2.18.1)
+    jwt (3.1.2)
+      base64
     kamal (2.10.1)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -161,6 +171,10 @@ GEM
     minitest (6.0.1)
       prism (~> 1.5)
     msgpack (1.8.0)
+    multi_xml (0.8.1)
+      bigdecimal (>= 3.1, < 5)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.6.2)
       date
       net-protocol
@@ -190,6 +204,30 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.1-x86_64-linux-musl)
       racc (~> 1.4)
+    oauth2 (2.0.18)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0, >= 2.0.3)
+      version_gem (~> 1.1, >= 1.1.9)
+    omniauth (2.1.4)
+      hashie (>= 3.4.6)
+      logger
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-google-oauth2 (1.2.2)
+      jwt (>= 2.9.2)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.9.0)
+      oauth2 (>= 2.0.2, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (2.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.10.1)
@@ -218,6 +256,10 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.5)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -315,6 +357,9 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    snaky_hash (2.0.3)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -367,6 +412,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
+    version_gem (1.1.9)
     web-console (4.3.0)
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
@@ -399,6 +445,9 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  omniauth
+  omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg (~> 1.6)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,20 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  helper_method :current_user, :logged_in?, :google_oauth_configured?
+
+  private
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+
+  def logged_in?
+    current_user.present?
+  end
+
+  def google_oauth_configured?
+    ENV["GOOGLE_CLIENT_ID"].present? && ENV["GOOGLE_CLIENT_SECRET"].present?
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,38 @@
+class SessionsController < ApplicationController
+  def create
+    auth = request.env["omniauth.auth"]
+
+    unless auth
+      redirect_to root_path, alert: "Google login failed."
+      return
+    end
+
+    identity = Identity.find_or_initialize_by(provider: auth.provider, uid: auth.uid)
+    user = identity.user || User.find_by(email: auth.info.email)
+
+    unless user
+      user = User.create!(
+        email: auth.info.email,
+        first_name: auth.info.first_name.presence || auth.info.name.to_s.split.first || "Unknown",
+        last_name: auth.info.last_name.presence || auth.info.name.to_s.split.drop(1).join(" ").presence || "Unknown",
+        role: "Member"
+      )
+    end
+
+    identity.user = user
+    identity.save!
+
+    session[:user_id] = user.id
+
+    redirect_to root_path, notice: "Signed in successfully."
+  end
+
+  def failure
+    redirect_to root_path, alert: params[:message].presence || "Google login failed."
+  end
+
+  def destroy
+    reset_session
+    redirect_to root_path, notice: "Signed out successfully."
+  end
+end

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -1,6 +1,37 @@
 <% content_for :title, "FMUG Conferences" %>
 
 <style>
+  .landing-auth {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .landing-auth__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    border: 1px solid #d6d3d1;
+    background: #ffffff;
+    color: #1c1917;
+    padding: 12px 18px;
+    font-size: 1.6rem;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .landing-auth__button:hover {
+    background: #f5f5f4;
+  }
+
+  .landing-auth__meta {
+    color: #57534e;
+    font-size: 1.5rem;
+  }
+
   sl-button.schedule-active::part(base) {
     background-color: lightgreen;
     color: #000;
@@ -8,6 +39,17 @@
 </style>
 
 <div class="flex w-full flex-col space-y-8">
+  <div class="landing-auth">
+    <% if logged_in? %>
+      <span class="landing-auth__meta">Signed in as <%= current_user.email %></span>
+      <%= button_to "Logout", logout_path, method: :delete, class: "landing-auth__button" %>
+    <% elsif google_oauth_configured? %>
+      <%= button_to "Login with Google", "/auth/google_oauth2", method: :post, class: "landing-auth__button" %>
+    <% else %>
+      <span class="landing-auth__meta">Google login is not configured yet.</span>
+    <% end %>
+  </div>
+
   <div class="flex w-full justify-center">
     <%= image_tag "fmug-400dpiLogo.jpeg", alt: "FMUG Logo", class: "mx-auto block h-auto max-h-[440px] w-auto max-w-full object-contain" %>
   </div>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,14 @@
+OmniAuth.config.allowed_request_methods = [ :post ]
+
+google_client_id = ENV["GOOGLE_CLIENT_ID"]
+google_client_secret = ENV["GOOGLE_CLIENT_SECRET"]
+
+if google_client_id.present? && google_client_secret.present?
+  Rails.application.config.middleware.use OmniAuth::Builder do
+    provider :google_oauth2,
+      google_client_id,
+      google_client_secret,
+      scope: "email,profile",
+      prompt: "select_account"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   resources :schedules
   resources :conferences
+  match "/auth/:provider/callback", to: "sessions#create", via: [ :get, :post ]
+  match "/auth/failure", to: "sessions#failure", via: [ :get, :post ]
+  delete "/logout", to: "sessions#destroy", as: :logout
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
Summary
- wire up Google OAuth so users can sign in with their existing Google/passkey setup instead of a new password
- surface login/logout controls on the landing page, with logout visible only when the user is authenticated

Testing
- Not run (not requested)