### PR TITLE
Update registration prompts and button styles

### DIFF
--- a/app/views/pages/_current.html.erb
+++ b/app/views/pages/_current.html.erb
@@ -33,7 +33,7 @@
             <span>Invite someone else to join the conference</span>
           </label>
           <div class="mt-6 flex justify-end">
-            <button type="button" class="rounded-full border border-blue-700 bg-blue-600 px-8 py-4 text-2xl font-semibold text-white shadow-sm transition hover:bg-blue-500">
+            <button type="button" class="rounded-full border border-stone-300 bg-white px-6 py-3 text-xl font-medium text-stone-800 transition hover:bg-stone-100">
               Next
             </button>
           </div>

--- a/app/views/pages/_current.html.erb
+++ b/app/views/pages/_current.html.erb
@@ -20,8 +20,24 @@
       </div>
 
       <div id="register-section" class="mt-6 hidden w-full max-w-xl rounded-2xl border border-stone-200 bg-white px-6 py-5 text-center shadow-sm">
-        <p class="text-sm font-semibold uppercase tracking-[0.18em] text-stone-500">Registration</p>
-        <p class="mt-2 text-2xl font-semibold text-stone-900"><%= registration_name || "unknown user" %></p>
+        <p class="text-lg font-semibold uppercase tracking-[0.18em] text-stone-500">Registration</p>
+        <p class="mt-2 text-4xl font-semibold text-stone-900"><%= registration_name || "unknown user" %></p>
+        <div class="mt-5 border-t border-stone-200 pt-5 text-left">
+          <p class="text-2xl font-medium text-stone-800">Who would you like to register?</p>
+          <label class="mt-8 flex items-center gap-4 text-xl text-stone-700">
+            <input type="radio" name="registration_type" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
+            <span>Register me for the conference</span>
+          </label>
+          <label class="mt-4 flex items-center gap-4 text-xl text-stone-700">
+            <input type="radio" name="registration_type" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
+            <span>Invite someone else to join the conference</span>
+          </label>
+          <div class="mt-6 flex justify-end">
+            <button type="button" class="rounded-full border border-blue-700 bg-blue-600 px-8 py-4 text-2xl font-semibold text-white shadow-sm transition hover:bg-blue-500">
+              Next
+            </button>
+          </div>
+        </div>
       </div>
   </div>
 <% else %>

--- a/app/views/pages/_current.html.erb
+++ b/app/views/pages/_current.html.erb
@@ -22,22 +22,28 @@
       <div id="register-section" class="hidden w-full max-w-xl rounded-2xl border border-stone-200 bg-white px-6 py-5 text-center shadow-sm" style="margin-top: 24px;">
         <p class="text-lg font-semibold uppercase tracking-[0.18em] text-stone-500">Registration</p>
         <p class="mt-2 text-4xl font-semibold text-stone-900"><%= registration_name || "unknown user" %></p>
-        <div class="mt-5 border-t border-stone-200 pt-5 text-left">
-          <p class="text-2xl font-medium text-stone-800">Who would you like to register?</p>
-          <label class="mt-8 flex items-center gap-4 text-xl text-stone-700">
-            <input type="radio" name="registration_type" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
-            <span>Register me for the conference</span>
-          </label>
-          <label class="mt-4 flex items-center gap-4 text-xl text-stone-700">
-            <input type="radio" name="registration_type" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
-            <span>Invite someone else to join the conference</span>
-          </label>
-          <div class="mt-6 flex justify-end">
-            <button type="button" class="rounded-full border border-stone-300 bg-white px-6 py-3 text-xl font-medium text-stone-800 transition hover:bg-stone-100">
-              Next
-            </button>
+        <% if logged_in? %>
+          <div class="mt-5 border-t border-stone-200 pt-5 text-left">
+            <p class="text-2xl font-medium text-stone-800">Who would you like to register?</p>
+            <label class="mt-8 flex items-center gap-4 text-xl text-stone-700">
+              <input type="radio" name="registration_type" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
+              <span>Register me for the conference</span>
+            </label>
+            <label class="mt-4 flex items-center gap-4 text-xl text-stone-700">
+              <input type="radio" name="registration_type" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
+              <span>Invite someone else to join the conference</span>
+            </label>
+            <div class="mt-6 flex justify-end">
+              <button type="button" class="rounded-full border border-stone-300 bg-white px-6 py-3 text-xl font-medium text-stone-800 transition hover:bg-stone-100">
+                Next
+              </button>
+            </div>
           </div>
-        </div>
+        <% else %>
+          <div class="mt-5 border-t border-stone-200 pt-5">
+            <p class="text-2xl font-medium text-stone-800">Please log in to register</p>
+          </div>
+        <% end %>
       </div>
   </div>
 <% else %>

--- a/app/views/pages/_current.html.erb
+++ b/app/views/pages/_current.html.erb
@@ -19,7 +19,7 @@
         <sl-button pill disabled>More information</sl-button>
       </div>
 
-      <div id="register-section" class="mt-6 hidden w-full max-w-xl rounded-2xl border border-stone-200 bg-white px-6 py-5 text-center shadow-sm">
+      <div id="register-section" class="hidden w-full max-w-xl rounded-2xl border border-stone-200 bg-white px-6 py-5 text-center shadow-sm" style="margin-top: 24px;">
         <p class="text-lg font-semibold uppercase tracking-[0.18em] text-stone-500">Registration</p>
         <p class="mt-2 text-4xl font-semibold text-stone-900"><%= registration_name || "unknown user" %></p>
         <div class="mt-5 border-t border-stone-200 pt-5 text-left">


### PR DESCRIPTION
Summary
- show the login prompt instead of the registration question for unauthenticated users
- tone down spacing changes to be 25% of the previous gap and simplify the <next> button appearance while keeping its hover state a light grey
- ensure the <next> button style remains subtle for now
Testing
- Not run (not requested)