### PR TITLE
Add invite modal prompting for name and email

### DIFF
--- a/app/views/pages/_current.html.erb
+++ b/app/views/pages/_current.html.erb
@@ -26,15 +26,15 @@
           <div class="mt-5 border-t border-stone-200 pt-5 text-left">
             <p class="text-2xl font-medium text-stone-800">Who would you like to register?</p>
             <label class="mt-8 flex items-center gap-4 text-xl text-stone-700">
-              <input type="radio" name="registration_type" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
+              <input type="radio" name="registration_type" id="register-self-option" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
               <span>Register me for the conference</span>
             </label>
             <label class="mt-4 flex items-center gap-4 text-xl text-stone-700">
-              <input type="radio" name="registration_type" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
+              <input type="radio" name="registration_type" id="invite-other-option" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
               <span>Invite someone else to join the conference</span>
             </label>
             <div class="mt-6 flex justify-end">
-              <button type="button" class="rounded-full border border-stone-300 bg-white px-6 py-3 text-xl font-medium text-stone-800 transition hover:bg-stone-100">
+              <button type="button" id="registration-next-button" class="rounded-full border border-stone-300 bg-white px-6 py-3 text-xl font-medium text-stone-800 transition hover:bg-stone-100">
                 Next
               </button>
             </div>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -32,6 +32,66 @@
     font-size: 1.5rem;
   }
 
+  .invite-modal[hidden] {
+    display: none;
+  }
+
+  .invite-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(28, 25, 23, 0.45);
+    padding: 24px;
+  }
+
+  .invite-modal__panel {
+    width: min(100%, 480px);
+    border-radius: 24px;
+    background: #ffffff;
+    padding: 28px;
+    box-shadow: 0 24px 60px rgba(28, 25, 23, 0.18);
+  }
+
+  .invite-modal__title {
+    font-size: 2.4rem;
+    font-weight: 600;
+    color: #1c1917;
+  }
+
+  .invite-modal__copy {
+    margin-top: 8px;
+    font-size: 1.5rem;
+    color: #57534e;
+  }
+
+  .invite-modal__field {
+    display: block;
+    margin-top: 18px;
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: #44403c;
+  }
+
+  .invite-modal__input {
+    margin-top: 8px;
+    width: 100%;
+    border: 1px solid #d6d3d1;
+    border-radius: 14px;
+    padding: 12px 14px;
+    font-size: 1.6rem;
+    color: #1c1917;
+  }
+
+  .invite-modal__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 24px;
+  }
+
   sl-button.is-active::part(base) {
     background-color: lightgreen;
     color: #000;
@@ -71,12 +131,59 @@
   </div>
 </div>
 
+<div id="invite-modal" class="invite-modal" hidden>
+  <div class="invite-modal__panel" role="dialog" aria-modal="true" aria-labelledby="invite-modal-title">
+    <h2 id="invite-modal-title" class="invite-modal__title">Invite attendee</h2>
+    <p class="invite-modal__copy">Enter the email address and first name for the invitation.</p>
+
+    <label class="invite-modal__field" for="invite-first-name-input">
+      First name
+      <input id="invite-first-name-input" class="invite-modal__input" type="text" autocomplete="given-name" />
+    </label>
+
+    <label class="invite-modal__field" for="invite-email-input">
+      Email address
+      <input id="invite-email-input" class="invite-modal__input" type="email" autocomplete="email" />
+    </label>
+
+    <div class="invite-modal__actions">
+      <button type="button" id="invite-modal-cancel" class="landing-auth__button">Cancel</button>
+      <button type="button" id="invite-modal-save" class="landing-auth__button">Continue</button>
+    </div>
+  </div>
+</div>
+
 <script>
   document.addEventListener("DOMContentLoaded", () => {
     const registerButton = document.getElementById("register-button");
     const registerSection = document.getElementById("register-section");
+    const registerSelfOption = document.getElementById("register-self-option");
+    const inviteOtherOption = document.getElementById("invite-other-option");
+    const registrationNextButton = document.getElementById("registration-next-button");
     const scheduleButton = document.getElementById("schedule-button");
     const scheduleSection = document.getElementById("schedule-section");
+    const inviteModal = document.getElementById("invite-modal");
+    const inviteEmailInput = document.getElementById("invite-email-input");
+    const inviteFirstNameInput = document.getElementById("invite-first-name-input");
+    const inviteModalCancel = document.getElementById("invite-modal-cancel");
+    const inviteModalSave = document.getElementById("invite-modal-save");
+
+    const closeInviteModal = () => {
+      if (!inviteModal) {
+        return;
+      }
+
+      inviteModal.hidden = true;
+    };
+
+    const openInviteModal = () => {
+      if (!inviteModal) {
+        return;
+      }
+
+      inviteModal.hidden = false;
+      inviteEmailInput?.focus();
+    };
 
     if (registerButton && registerSection) {
       registerButton.addEventListener("click", () => {
@@ -101,5 +208,24 @@
         }
       });
     }
+
+    if (registrationNextButton && inviteOtherOption) {
+      registrationNextButton.addEventListener("click", () => {
+        if (!inviteOtherOption.checked) {
+          return;
+        }
+
+        openInviteModal();
+      });
+    }
+
+    inviteModalCancel?.addEventListener("click", closeInviteModal);
+    inviteModalSave?.addEventListener("click", closeInviteModal);
+
+    inviteModal?.addEventListener("click", (event) => {
+      if (event.target === inviteModal) {
+        closeInviteModal();
+      }
+    });
   });
 </script>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -92,6 +92,23 @@
     margin-top: 24px;
   }
 
+  .invite-modal__error {
+    margin-top: 14px;
+    font-size: 1.4rem;
+    color: #b91c1c;
+  }
+
+  .invite-modal__draft {
+    margin-top: 20px;
+    border-radius: 18px;
+    background: #f5f5f4;
+    padding: 18px;
+    font-size: 1.5rem;
+    line-height: 1.7;
+    color: #292524;
+    white-space: pre-line;
+  }
+
   sl-button.is-active::part(base) {
     background-color: lightgreen;
     color: #000;
@@ -138,13 +155,15 @@
 
     <label class="invite-modal__field" for="invite-first-name-input">
       First name
-      <input id="invite-first-name-input" class="invite-modal__input" type="text" autocomplete="given-name" />
+      <input id="invite-first-name-input" class="invite-modal__input" type="text" autocomplete="given-name" required />
     </label>
 
     <label class="invite-modal__field" for="invite-email-input">
       Email address
-      <input id="invite-email-input" class="invite-modal__input" type="email" autocomplete="email" />
+      <input id="invite-email-input" class="invite-modal__input" type="email" autocomplete="email" required />
     </label>
+
+    <p id="invite-modal-error" class="invite-modal__error" hidden>Please enter both the first name and email address before continuing.</p>
 
     <div class="invite-modal__actions">
       <button type="button" id="invite-modal-cancel" class="landing-auth__button">Cancel</button>
@@ -153,8 +172,22 @@
   </div>
 </div>
 
+<div id="invite-preview-modal" class="invite-modal" hidden>
+  <div class="invite-modal__panel" role="dialog" aria-modal="true" aria-labelledby="invite-preview-title">
+    <h2 id="invite-preview-title" class="invite-modal__title">Invitation draft</h2>
+    <p class="invite-modal__copy">Preview of the email that would be sent.</p>
+
+    <div id="invite-preview-body" class="invite-modal__draft"></div>
+
+    <div class="invite-modal__actions">
+      <button type="button" id="invite-preview-close" class="landing-auth__button">Close</button>
+    </div>
+  </div>
+</div>
+
 <script>
   document.addEventListener("DOMContentLoaded", () => {
+    const signedInUserName = "<%= j([current_user&.first_name, current_user&.last_name].compact.join(" ").presence || current_user&.email.to_s) %>";
     const registerButton = document.getElementById("register-button");
     const registerSection = document.getElementById("register-section");
     const registerSelfOption = document.getElementById("register-self-option");
@@ -165,8 +198,12 @@
     const inviteModal = document.getElementById("invite-modal");
     const inviteEmailInput = document.getElementById("invite-email-input");
     const inviteFirstNameInput = document.getElementById("invite-first-name-input");
+    const inviteModalError = document.getElementById("invite-modal-error");
     const inviteModalCancel = document.getElementById("invite-modal-cancel");
     const inviteModalSave = document.getElementById("invite-modal-save");
+    const invitePreviewModal = document.getElementById("invite-preview-modal");
+    const invitePreviewBody = document.getElementById("invite-preview-body");
+    const invitePreviewClose = document.getElementById("invite-preview-close");
 
     const closeInviteModal = () => {
       if (!inviteModal) {
@@ -181,8 +218,34 @@
         return;
       }
 
+      inviteModalError.hidden = true;
       inviteModal.hidden = false;
-      inviteEmailInput?.focus();
+      inviteFirstNameInput?.focus();
+    };
+
+    const closeInvitePreviewModal = () => {
+      if (!invitePreviewModal) {
+        return;
+      }
+
+      invitePreviewModal.hidden = true;
+    };
+
+    const openInvitePreviewModal = (invitedFirstName) => {
+      if (!invitePreviewModal || !invitePreviewBody) {
+        return;
+      }
+
+      invitePreviewBody.textContent = `Hi ${invitedFirstName},
+
+I would like to invite you to join the upcoming FMUG conference.
+
+This is placeholder text for the invitation email body. We will replace this draft with the real conference details later.
+
+Best regards,
+${signedInUserName}`;
+
+      invitePreviewModal.hidden = false;
     };
 
     if (registerButton && registerSection) {
@@ -220,11 +283,30 @@
     }
 
     inviteModalCancel?.addEventListener("click", closeInviteModal);
-    inviteModalSave?.addEventListener("click", closeInviteModal);
+    inviteModalSave?.addEventListener("click", () => {
+      const invitedFirstName = inviteFirstNameInput?.value.trim();
+      const invitedEmail = inviteEmailInput?.value.trim();
+
+      if (!invitedFirstName || !invitedEmail) {
+        inviteModalError.hidden = false;
+        return;
+      }
+
+      inviteModalError.hidden = true;
+      closeInviteModal();
+      openInvitePreviewModal(invitedFirstName);
+    });
+    invitePreviewClose?.addEventListener("click", closeInvitePreviewModal);
 
     inviteModal?.addEventListener("click", (event) => {
       if (event.target === inviteModal) {
         closeInviteModal();
+      }
+    });
+
+    invitePreviewModal?.addEventListener("click", (event) => {
+      if (event.target === invitePreviewModal) {
+        closeInvitePreviewModal();
       }
     });
   });


### PR DESCRIPTION
**Summary**
- fix string-literal style issues reported in rubocop
- open a modal after selecting invite flow that first asks for the invitee’s first name and email (email below, both required)
- continue button now shows a placeholder draft email that addresses the invitee by their first name and signs with the current user’s name

**Testing**
- Not run (not requested)