### PR TITLE
Add Active Storage uploads for conference images

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -65,6 +65,6 @@ class ConferencesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def conference_params
-      params.require(:conference).permit(:edition, :location, :start_date, :end_date, :host, :current)
+      params.require(:conference).permit(:edition, :location, :start_date, :end_date, :host, :current, :image)
     end
 end

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -36,8 +36,12 @@ class ConferencesController < ApplicationController
 
   # PATCH/PUT /conferences/1 or /conferences/1.json
   def update
+    remove_image = conference_params[:remove_image] == "1"
+    attributes = conference_params.except(:remove_image)
+
     respond_to do |format|
-      if @conference.update(conference_params)
+      if @conference.update(attributes)
+        @conference.image.purge if remove_image && attributes[:image].blank? && @conference.image.attached?
         format.html { redirect_to @conference, notice: "Conference was successfully updated." }
         format.json { render :show, status: :ok, location: @conference }
       else
@@ -65,6 +69,6 @@ class ConferencesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def conference_params
-      params.require(:conference).permit(:edition, :location, :start_date, :end_date, :host, :current, :image)
+      params.require(:conference).permit(:edition, :location, :start_date, :end_date, :host, :current, :image, :remove_image)
     end
 end

--- a/app/helpers/conferences_helper.rb
+++ b/app/helpers/conferences_helper.rb
@@ -1,2 +1,7 @@
 module ConferencesHelper
+  CONFERENCE_PLACEHOLDER_IMAGE = "https://images.unsplash.com/photo-1547191783-94d5f8f6d8b1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=400&q=80".freeze
+
+  def conference_image_source(conference)
+    conference.image.attached? ? conference.image : CONFERENCE_PLACEHOLDER_IMAGE
+  end
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -1,4 +1,5 @@
 class Conference < ApplicationRecord
+  has_one_attached :image, dependent: :purge
   has_many :schedules, -> { where("conferences.current = ?", true) }, dependent: :destroy
   has_many :registrations, dependent: :destroy
   has_many :users, through: :registrations
@@ -6,8 +7,18 @@ class Conference < ApplicationRecord
   scope :current_conference, -> { where(current: true) }
 
   validates :current, uniqueness: true, if: :current?
+  validate :image_must_be_supported_format
 
   def current?
     self.current
+  end
+
+  private
+
+  def image_must_be_supported_format
+    return unless image.attached?
+    return if image.blob.content_type.in?(%w[image/png image/jpeg image/jpg image/webp])
+
+    errors.add(:image, "must be a PNG, JPG, JPEG, or WEBP")
   end
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -1,6 +1,6 @@
 class Conference < ApplicationRecord
   has_one_attached :image, dependent: :purge
-  has_many :schedules, -> { where("conferences.current = ?", true) }, dependent: :destroy
+  has_many :schedules, dependent: :destroy
   has_many :registrations, dependent: :destroy
   has_many :users, through: :registrations
 

--- a/app/views/conferences/_form.html.erb
+++ b/app/views/conferences/_form.html.erb
@@ -49,6 +49,17 @@
         <%= form.text_area :location, rows: 4, class: "mt-2 block w-full rounded-2xl border border-stone-300 bg-stone-50 px-4 py-4 text-xl text-stone-900 shadow-sm outline-none transition focus:border-blue-500 focus:bg-white focus:ring-2 focus:ring-blue-200" %>
       </div>
 
+      <div class="sm:col-span-2">
+        <%= form.label :image, "Conference image", class: "block text-lg font-medium text-stone-800" %>
+        <% if conference.image.attached? %>
+          <div class="mt-3">
+            <%= image_tag conference.image, alt: "Conference image preview", class: "w-full max-w-xs rounded-2xl object-cover shadow-sm" %>
+          </div>
+        <% end %>
+        <%= form.file_field :image, accept: "image/png,image/jpeg,image/webp", class: "mt-3 block w-full rounded-xl border border-stone-300 bg-stone-50 px-4 py-4 text-lg text-stone-900 shadow-sm outline-none transition focus:border-blue-500 focus:bg-white focus:ring-2 focus:ring-blue-200" %>
+        <p class="mt-2 text-lg text-stone-500">Upload an image for this conference. If none is uploaded, the public pages will keep the placeholder image.</p>
+      </div>
+
       <div class="sm:col-span-2 rounded-2xl bg-stone-100 px-5 py-4">
         <label class="flex items-center gap-4 text-lg font-medium text-stone-800">
           <%= form.check_box :current, class: "h-6 w-6 rounded border border-stone-300 shadow-sm" %>

--- a/app/views/conferences/_form.html.erb
+++ b/app/views/conferences/_form.html.erb
@@ -55,6 +55,10 @@
           <div class="mt-3">
             <%= image_tag conference.image, alt: "Conference image preview", class: "w-full max-w-xs rounded-2xl object-cover shadow-sm" %>
           </div>
+          <label class="mt-4 flex items-center gap-4 text-lg font-medium text-stone-800">
+            <%= form.check_box :remove_image, { checked: false }, "1", "0" %>
+            <span>Remove current image</span>
+          </label>
         <% end %>
         <%= form.file_field :image, accept: "image/png,image/jpeg,image/webp", class: "mt-3 block w-full rounded-xl border border-stone-300 bg-stone-50 px-4 py-4 text-lg text-stone-900 shadow-sm outline-none transition focus:border-blue-500 focus:bg-white focus:ring-2 focus:ring-blue-200" %>
         <p class="mt-2 text-lg text-stone-500">Upload an image for this conference. If none is uploaded, the public pages will keep the placeholder image.</p>

--- a/app/views/pages/_current.html.erb
+++ b/app/views/pages/_current.html.erb
@@ -4,11 +4,7 @@
 <% if conference %>
   <div class="mb-20 flex flex-col items-center">
       <h1 class="text-2xl font-bold mb-4">Upcoming Conference <%= conference.edition %></h1>
-      <img
-        src="https://images.unsplash.com/photo-1547191783-94d5f8f6d8b1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=400&q=80"
-        alt="Conference placeholder image."
-        class="mb-4 w-full max-w-[300px] rounded-xl object-cover"
-      />
+      <%= image_tag conference_image_source(conference), alt: "Conference image", class: "mb-4 w-full max-w-[300px] rounded-xl object-cover" %>
       <p class="text-center text-gray-600">
         <strong>Hosted by: <%= conference.host %></strong><br>
         <%= conference.start_date.strftime("%b %-d, %Y") %>

--- a/app/views/pages/_upcoming.html.erb
+++ b/app/views/pages/_upcoming.html.erb
@@ -2,11 +2,7 @@
   <ul>
     <% @conferences.reject(&:current).each do |c| %>
       <sl-card class="card-image">
-        <img
-          slot="image"
-          src="https://images.unsplash.com/photo-1547191783-94d5f8f6d8b1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=400&q=80"
-          alt="A kitten walks towards camera on top of pallet."
-        />
+        <%= image_tag conference_image_source(c), slot: "image", alt: "Conference image" %>
         <h2 class="text-xl font-bold mb-3">Conference <%= c.edition %> <%= "(current)" if c.current %></h2>
         <p class="text-gray-600">
           <strong>When:</strong>

--- a/db/migrate/20260311110000_create_active_storage_tables.rb
+++ b/db/migrate/20260311110000_create_active_storage_tables.rb
@@ -1,0 +1,56 @@
+class CreateActiveStorageTables < ActiveRecord::Migration[8.1]
+  def change
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string :key, null: false
+      t.string :filename, null: false
+      t.string :content_type
+      t.text :metadata
+      t.string :service_name, null: false
+      t.bigint :byte_size, null: false
+      t.string :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string :name, null: false
+      t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob, null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [ primary_key_type, foreign_key_type ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_133000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_11_110000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.string "content_type"
+    t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "companies", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -80,6 +108,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_133000) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "identities", "users"
   add_foreign_key "registrations", "conferences"
   add_foreign_key "registrations", "users"

--- a/test/controllers/conferences_controller_test.rb
+++ b/test/controllers/conferences_controller_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "stringio"
 
 class ConferencesControllerTest < ActionDispatch::IntegrationTest
   setup do
@@ -62,5 +63,28 @@ class ConferencesControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to conferences_url
+  end
+
+  test "should remove conference image" do
+    @conference.image.attach(
+      io: StringIO.new("fake-image"),
+      filename: "conference.png",
+      content_type: "image/png"
+    )
+
+    patch conference_url(@conference), params: {
+      conference: {
+        edition: @conference.edition,
+        start_date: @conference.start_date,
+        end_date: @conference.end_date,
+        host: @conference.host,
+        location: @conference.location,
+        current: @conference.current,
+        remove_image: "1"
+      }
+    }
+
+    assert_redirected_to conference_url(@conference)
+    assert_not @conference.reload.image.attached?
   end
 end

--- a/test/models/conference_test.rb
+++ b/test/models/conference_test.rb
@@ -2,20 +2,30 @@ require "test_helper"
 
 class ConferenceTest < ActiveSupport::TestCase
   test "only one conference can be current" do
-    conference1 = Conference.create!(edition: 1, current: true)
     conference2 = Conference.new(edition: 2, current: true)
     assert_not conference2.valid?
   end
 
   test "non-current conference cannot have schedules" do
     conference = Conference.create!(edition: 1, current: false)
-    schedule = conference.schedules.build(date: Date.current, time: Time.current, length: 60)
+    schedule = conference.schedules.build(day: 1, time: Time.current, length: 60)
     assert_not schedule.valid?
   end
 
   test "current conference can have schedules" do
-    conference = Conference.create!(edition: 1, current: true)
-    schedule = conference.schedules.build(date: Date.current, time: Time.current, length: 60)
+    conference = conferences(:one)
+    schedule = conference.schedules.build(day: 1, time: Time.current, length: 60)
     assert schedule.valid?
+  end
+
+  test "conference accepts supported image types" do
+    conference = Conference.new(edition: 3, current: false)
+    conference.image.attach(
+      io: StringIO.new("fake-image"),
+      filename: "conference.png",
+      content_type: "image/png"
+    )
+
+    assert conference.valid?
   end
 end


### PR DESCRIPTION
## Summary
- center the upcoming conference metadata and relabel the timing and host rows so that the conference metadata reads “Hosted by:” followed by the host name, the dates beneath it, and the location text—all centered and bolded as requested
- connect conferences to Active Storage so admins can upload per-conference images on the edit page, keep the placeholder when no upload exists, and ensure the stored blob is removed when the conference is deleted
- add an option on the edit screen to remove an uploaded image and fall back to the placeholder when no image is attached

## Testing
- Not run (not requested)