### PR TITLE
Add additional registration questions and persistence

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -17,7 +17,15 @@ class RegistrationsController < ApplicationController
 
     current_user.registrations.create!(
       conference: @conference,
-      attending_physically: attendance_mode == "physical"
+      attending_physically: attendance_mode == "physical",
+      agenda_present: registration_params[:agenda_present],
+      agenda_question: registration_params[:agenda_question],
+      agenda_something_else: registration_params[:agenda_something_else],
+      agenda_something_else_text: registration_params[:agenda_something_else_text],
+      agenda_nothing_to_present: registration_params[:agenda_nothing_to_present],
+      has_dietary_requirements: registration_params[:has_dietary_requirements],
+      dietary_requirements_text: registration_params[:dietary_requirements_text],
+      chair_note: registration_params[:chair_note]
     )
 
     redirect_to root_path, notice: "You are registered for Conference #{@conference.edition}."
@@ -47,6 +55,16 @@ class RegistrationsController < ApplicationController
   end
 
   def registration_params
-    params.require(:registration).permit(:attendance_mode)
+    params.require(:registration).permit(
+      :attendance_mode,
+      :agenda_present,
+      :agenda_question,
+      :agenda_something_else,
+      :agenda_something_else_text,
+      :agenda_nothing_to_present,
+      :has_dietary_requirements,
+      :dietary_requirements_text,
+      :chair_note
+    )
   end
 end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -4,4 +4,33 @@ class Registration < ApplicationRecord
 
   validates :attending_physically, inclusion: { in: [ true, false ] }
   validates :user_id, uniqueness: { scope: :conference_id }
+  validate :agenda_selection_required
+  validate :dietary_requirements_text_needed
+
+  before_validation :normalize_optional_text_fields
+
+  private
+
+  def agenda_selection_required
+    return if agenda_present || agenda_question || agenda_something_else || agenda_nothing_to_present
+
+    errors.add(:base, "Select at least one agenda option")
+  end
+
+  def dietary_requirements_text_needed
+    return unless has_dietary_requirements
+    return if dietary_requirements_text.present?
+
+    errors.add(:dietary_requirements_text, "must be provided when dietary requirements are selected")
+  end
+
+  def normalize_optional_text_fields
+    self.agenda_something_else_text = agenda_something_else_text.to_s.strip.presence
+    self.chair_note = chair_note.to_s.strip.presence
+
+    cleaned_dietary_text = dietary_requirements_text.to_s.strip
+    self.dietary_requirements_text = if has_dietary_requirements && cleaned_dietary_text != "Please specify"
+      cleaned_dietary_text.presence
+    end
+  end
 end

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -258,6 +258,14 @@ end %>
         </label>
 
         <%= form.hidden_field :attendance_mode, id: "attendance-mode-value" %>
+        <%= form.hidden_field :agenda_present, id: "agenda-present-value", value: "0" %>
+        <%= form.hidden_field :agenda_question, id: "agenda-question-value", value: "0" %>
+        <%= form.hidden_field :agenda_something_else, id: "agenda-something-else-value", value: "0" %>
+        <%= form.hidden_field :agenda_something_else_text, id: "agenda-something-else-text-value" %>
+        <%= form.hidden_field :agenda_nothing_to_present, id: "agenda-nothing-value", value: "0" %>
+        <%= form.hidden_field :has_dietary_requirements, id: "dietary-requirements-value", value: "0" %>
+        <%= form.hidden_field :dietary_requirements_text, id: "dietary-requirements-text-value" %>
+        <%= form.hidden_field :chair_note, id: "chair-note-value" %>
 
         <p id="self-registration-error" class="registration-modal__error" hidden>Please choose either physical or online attendance to continue.</p>
 
@@ -444,6 +452,11 @@ end %>
     const agendaSomethingElseOption = document.getElementById("agenda-something-else-option");
     const agendaSomethingElseText = document.getElementById("agenda-something-else-text");
     const agendaNothingOption = document.getElementById("agenda-nothing-option");
+    const agendaPresentValue = document.getElementById("agenda-present-value");
+    const agendaQuestionValue = document.getElementById("agenda-question-value");
+    const agendaSomethingElseValue = document.getElementById("agenda-something-else-value");
+    const agendaSomethingElseTextValue = document.getElementById("agenda-something-else-text-value");
+    const agendaNothingValue = document.getElementById("agenda-nothing-value");
     const dietaryRequirementsModal = document.getElementById("dietary-requirements-modal");
     const dietaryRequirementsCancel = document.getElementById("dietary-requirements-cancel");
     const dietaryRequirementsContinue = document.getElementById("dietary-requirements-continue");
@@ -451,9 +464,13 @@ end %>
     const dietaryRequirementsYes = document.getElementById("dietary-requirements-yes");
     const dietaryRequirementsNo = document.getElementById("dietary-requirements-no");
     const dietaryRequirementsText = document.getElementById("dietary-requirements-text");
+    const dietaryRequirementsValue = document.getElementById("dietary-requirements-value");
+    const dietaryRequirementsTextValue = document.getElementById("dietary-requirements-text-value");
     const registrationNoteModal = document.getElementById("registration-note-modal");
     const registrationNoteCancel = document.getElementById("registration-note-cancel");
     const registrationNoteContinue = document.getElementById("registration-note-continue");
+    const registrationNoteText = document.getElementById("registration-note-text");
+    const chairNoteValue = document.getElementById("chair-note-value");
     const inviteModal = document.getElementById("invite-modal");
     const inviteEmailInput = document.getElementById("invite-email-input");
     const inviteFirstNameInput = document.getElementById("invite-first-name-input");
@@ -690,6 +707,26 @@ ${signedInUserName}`;
         agendaReservationError.hidden = true;
       }
 
+      if (agendaPresentValue) {
+        agendaPresentValue.value = agendaPresentOption?.checked ? "1" : "0";
+      }
+
+      if (agendaQuestionValue) {
+        agendaQuestionValue.value = agendaQuestionOption?.checked ? "1" : "0";
+      }
+
+      if (agendaSomethingElseValue) {
+        agendaSomethingElseValue.value = agendaSomethingElseOption?.checked ? "1" : "0";
+      }
+
+      if (agendaSomethingElseTextValue) {
+        agendaSomethingElseTextValue.value = agendaSomethingElseText?.value.trim() || "";
+      }
+
+      if (agendaNothingValue) {
+        agendaNothingValue.value = agendaNothingOption?.checked ? "1" : "0";
+      }
+
       closeAgendaReservationModal();
       openDietaryRequirementsModal();
     });
@@ -733,12 +770,24 @@ ${signedInUserName}`;
         dietaryRequirementsError.hidden = true;
       }
 
+      if (dietaryRequirementsValue) {
+        dietaryRequirementsValue.value = dietaryRequirementsYes?.checked ? "1" : "0";
+      }
+
+      if (dietaryRequirementsTextValue) {
+        dietaryRequirementsTextValue.value = dietaryRequirementsYes?.checked ? (dietaryDetails || "") : "";
+      }
+
       closeDietaryRequirementsModal();
       openRegistrationNoteModal();
     });
 
     registrationNoteCancel?.addEventListener("click", closeRegistrationNoteModal);
     registrationNoteContinue?.addEventListener("click", () => {
+      if (chairNoteValue) {
+        chairNoteValue.value = registrationNoteText?.value.trim() || "";
+      }
+
       closeRegistrationNoteModal();
       selfRegistrationReadyToSubmit = true;
       selfRegistrationForm?.requestSubmit();

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -112,6 +112,18 @@ end %>
     color: #1c1917;
   }
 
+  .registration-modal__textarea {
+    margin-top: 14px;
+    width: 100%;
+    min-height: 140px;
+    border: 1px solid #d6d3d1;
+    border-radius: 14px;
+    padding: 14px 16px;
+    font-size: 1.6rem;
+    color: #1c1917;
+    resize: vertical;
+  }
+
   .invite-modal[hidden] {
     display: none;
   }
@@ -346,6 +358,24 @@ end %>
   </div>
 </div>
 
+<div id="registration-note-modal" class="registration-modal" hidden>
+  <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="registration-note-title">
+    <h2 id="registration-note-title" class="registration-modal__title">Something else</h2>
+    <p class="registration-modal__copy">Leave a message for the Chair regarding the agenda or registration. For example, whether a visa is needed.</p>
+
+    <textarea
+      id="registration-note-text"
+      class="registration-modal__textarea"
+      placeholder="Optional message for the Chair"
+    ></textarea>
+
+    <div class="registration-modal__actions">
+      <button type="button" id="registration-note-cancel" class="landing-auth__button">Cancel</button>
+      <button type="button" id="registration-note-continue" class="landing-auth__button">Continue</button>
+    </div>
+  </div>
+</div>
+
 <div id="invite-modal" class="invite-modal" hidden>
   <div class="invite-modal__panel" role="dialog" aria-modal="true" aria-labelledby="invite-modal-title">
     <h2 id="invite-modal-title" class="invite-modal__title">Invite attendee</h2>
@@ -421,6 +451,9 @@ end %>
     const dietaryRequirementsYes = document.getElementById("dietary-requirements-yes");
     const dietaryRequirementsNo = document.getElementById("dietary-requirements-no");
     const dietaryRequirementsText = document.getElementById("dietary-requirements-text");
+    const registrationNoteModal = document.getElementById("registration-note-modal");
+    const registrationNoteCancel = document.getElementById("registration-note-cancel");
+    const registrationNoteContinue = document.getElementById("registration-note-continue");
     const inviteModal = document.getElementById("invite-modal");
     const inviteEmailInput = document.getElementById("invite-email-input");
     const inviteFirstNameInput = document.getElementById("invite-first-name-input");
@@ -495,6 +528,22 @@ end %>
       }
 
       dietaryRequirementsModal.hidden = false;
+    };
+
+    const closeRegistrationNoteModal = () => {
+      if (!registrationNoteModal) {
+        return;
+      }
+
+      registrationNoteModal.hidden = true;
+    };
+
+    const openRegistrationNoteModal = () => {
+      if (!registrationNoteModal) {
+        return;
+      }
+
+      registrationNoteModal.hidden = false;
     };
 
     const closeInviteModal = () => {
@@ -685,6 +734,12 @@ ${signedInUserName}`;
       }
 
       closeDietaryRequirementsModal();
+      openRegistrationNoteModal();
+    });
+
+    registrationNoteCancel?.addEventListener("click", closeRegistrationNoteModal);
+    registrationNoteContinue?.addEventListener("click", () => {
+      closeRegistrationNoteModal();
       selfRegistrationReadyToSubmit = true;
       selfRegistrationForm?.requestSubmit();
     });
@@ -726,6 +781,12 @@ ${signedInUserName}`;
     dietaryRequirementsModal?.addEventListener("click", (event) => {
       if (event.target === dietaryRequirementsModal) {
         closeDietaryRequirementsModal();
+      }
+    });
+
+    registrationNoteModal?.addEventListener("click", (event) => {
+      if (event.target === registrationNoteModal) {
+        closeRegistrationNoteModal();
       }
     });
 

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -312,6 +312,40 @@ end %>
   </div>
 </div>
 
+<div id="dietary-requirements-modal" class="registration-modal" hidden>
+  <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="dietary-requirements-title">
+    <h2 id="dietary-requirements-title" class="registration-modal__title">Do you have any dietary requirements</h2>
+    <p class="registration-modal__copy">Select yes or no.</p>
+
+    <div class="mt-5">
+      <label class="registration-modal__choice" for="dietary-requirements-yes">
+        <input type="radio" name="dietary_requirements" id="dietary-requirements-yes" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
+        <span>Yes</span>
+      </label>
+
+      <input
+        id="dietary-requirements-text"
+        type="text"
+        class="registration-modal__text-input"
+        value="Please specify"
+        hidden
+      />
+    </div>
+
+    <label class="registration-modal__choice" for="dietary-requirements-no">
+      <input type="radio" name="dietary_requirements" id="dietary-requirements-no" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
+      <span>No</span>
+    </label>
+
+    <p id="dietary-requirements-error" class="registration-modal__error" hidden>Please choose yes or no before continuing.</p>
+
+    <div class="registration-modal__actions">
+      <button type="button" id="dietary-requirements-cancel" class="landing-auth__button">Cancel</button>
+      <button type="button" id="dietary-requirements-continue" class="landing-auth__button">Continue</button>
+    </div>
+  </div>
+</div>
+
 <div id="invite-modal" class="invite-modal" hidden>
   <div class="invite-modal__panel" role="dialog" aria-modal="true" aria-labelledby="invite-modal-title">
     <h2 id="invite-modal-title" class="invite-modal__title">Invite attendee</h2>
@@ -380,6 +414,13 @@ end %>
     const agendaSomethingElseOption = document.getElementById("agenda-something-else-option");
     const agendaSomethingElseText = document.getElementById("agenda-something-else-text");
     const agendaNothingOption = document.getElementById("agenda-nothing-option");
+    const dietaryRequirementsModal = document.getElementById("dietary-requirements-modal");
+    const dietaryRequirementsCancel = document.getElementById("dietary-requirements-cancel");
+    const dietaryRequirementsContinue = document.getElementById("dietary-requirements-continue");
+    const dietaryRequirementsError = document.getElementById("dietary-requirements-error");
+    const dietaryRequirementsYes = document.getElementById("dietary-requirements-yes");
+    const dietaryRequirementsNo = document.getElementById("dietary-requirements-no");
+    const dietaryRequirementsText = document.getElementById("dietary-requirements-text");
     const inviteModal = document.getElementById("invite-modal");
     const inviteEmailInput = document.getElementById("invite-email-input");
     const inviteFirstNameInput = document.getElementById("invite-first-name-input");
@@ -434,6 +475,26 @@ end %>
       }
 
       agendaReservationModal.hidden = false;
+    };
+
+    const closeDietaryRequirementsModal = () => {
+      if (!dietaryRequirementsModal) {
+        return;
+      }
+
+      dietaryRequirementsModal.hidden = true;
+    };
+
+    const openDietaryRequirementsModal = () => {
+      if (!dietaryRequirementsModal) {
+        return;
+      }
+
+      if (dietaryRequirementsError) {
+        dietaryRequirementsError.hidden = true;
+      }
+
+      dietaryRequirementsModal.hidden = false;
     };
 
     const closeInviteModal = () => {
@@ -581,6 +642,49 @@ ${signedInUserName}`;
       }
 
       closeAgendaReservationModal();
+      openDietaryRequirementsModal();
+    });
+
+    dietaryRequirementsYes?.addEventListener("change", () => {
+      if (dietaryRequirementsText) {
+        dietaryRequirementsText.hidden = false;
+        dietaryRequirementsText.focus();
+      }
+    });
+
+    dietaryRequirementsNo?.addEventListener("change", () => {
+      if (dietaryRequirementsText) {
+        dietaryRequirementsText.hidden = true;
+      }
+    });
+
+    dietaryRequirementsCancel?.addEventListener("click", closeDietaryRequirementsModal);
+    dietaryRequirementsContinue?.addEventListener("click", () => {
+      if (!dietaryRequirementsYes?.checked && !dietaryRequirementsNo?.checked) {
+        if (dietaryRequirementsError) {
+          dietaryRequirementsError.hidden = false;
+          dietaryRequirementsError.textContent = "Please choose yes or no before continuing.";
+        }
+
+        return;
+      }
+
+      const dietaryDetails = dietaryRequirementsText?.value.trim();
+
+      if (dietaryRequirementsYes?.checked && (!dietaryDetails || dietaryDetails === "Please specify")) {
+        if (dietaryRequirementsError) {
+          dietaryRequirementsError.hidden = false;
+          dietaryRequirementsError.textContent = "Please specify your dietary requirements before continuing.";
+        }
+
+        return;
+      }
+
+      if (dietaryRequirementsError) {
+        dietaryRequirementsError.hidden = true;
+      }
+
+      closeDietaryRequirementsModal();
       selfRegistrationReadyToSubmit = true;
       selfRegistrationForm?.requestSubmit();
     });
@@ -616,6 +720,12 @@ ${signedInUserName}`;
     agendaReservationModal?.addEventListener("click", (event) => {
       if (event.target === agendaReservationModal) {
         closeAgendaReservationModal();
+      }
+    });
+
+    dietaryRequirementsModal?.addEventListener("click", (event) => {
+      if (event.target === dietaryRequirementsModal) {
+        closeDietaryRequirementsModal();
       }
     });
 

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -102,6 +102,16 @@ end %>
     color: #44403c;
   }
 
+  .registration-modal__text-input {
+    margin-top: 10px;
+    width: 100%;
+    border: 1px solid #d6d3d1;
+    border-radius: 14px;
+    padding: 12px 14px;
+    font-size: 1.6rem;
+    color: #1c1917;
+  }
+
   .invite-modal[hidden] {
     display: none;
   }
@@ -260,6 +270,48 @@ end %>
   </div>
 </div>
 
+<div id="agenda-reservation-modal" class="registration-modal" hidden>
+  <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="agenda-reservation-title">
+    <h2 id="agenda-reservation-title" class="registration-modal__title">Please reserve time on the agenda</h2>
+    <p class="registration-modal__copy">Select one or more options below.</p>
+
+    <label class="registration-modal__choice" for="agenda-present-option">
+      <input type="checkbox" id="agenda-present-option" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
+      <span>Present / Pitch an idea to the community</span>
+    </label>
+
+    <label class="registration-modal__choice" for="agenda-question-option">
+      <input type="checkbox" id="agenda-question-option" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
+      <span>Ask a question/discuss a topic</span>
+    </label>
+
+    <div class="mt-5">
+      <label class="registration-modal__choice" for="agenda-something-else-option">
+        <input type="checkbox" id="agenda-something-else-option" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
+        <span>Something else</span>
+      </label>
+      <input
+        id="agenda-something-else-text"
+        type="text"
+        class="registration-modal__text-input"
+        placeholder="Add a note"
+      />
+    </div>
+
+    <label class="registration-modal__choice" for="agenda-nothing-option">
+      <input type="checkbox" id="agenda-nothing-option" class="h-6 w-6 border-stone-300 text-blue-600 focus:ring-blue-500" />
+      <span>Nothing to present</span>
+    </label>
+
+    <p id="agenda-reservation-error" class="registration-modal__error" hidden>Please select at least one option before continuing.</p>
+
+    <div class="registration-modal__actions">
+      <button type="button" id="agenda-reservation-cancel" class="landing-auth__button">Cancel</button>
+      <button type="button" id="agenda-reservation-continue" class="landing-auth__button">Continue</button>
+    </div>
+  </div>
+</div>
+
 <div id="invite-modal" class="invite-modal" hidden>
   <div class="invite-modal__panel" role="dialog" aria-modal="true" aria-labelledby="invite-modal-title">
     <h2 id="invite-modal-title" class="invite-modal__title">Invite attendee</h2>
@@ -319,6 +371,15 @@ end %>
     const selfRegistrationCreatePanel = document.getElementById("self-registration-create-panel");
     const selfRegistrationRemovePanel = document.getElementById("self-registration-remove-panel");
     const selfRegistrationForm = document.getElementById("self-registration-form");
+    const agendaReservationModal = document.getElementById("agenda-reservation-modal");
+    const agendaReservationCancel = document.getElementById("agenda-reservation-cancel");
+    const agendaReservationContinue = document.getElementById("agenda-reservation-continue");
+    const agendaReservationError = document.getElementById("agenda-reservation-error");
+    const agendaPresentOption = document.getElementById("agenda-present-option");
+    const agendaQuestionOption = document.getElementById("agenda-question-option");
+    const agendaSomethingElseOption = document.getElementById("agenda-something-else-option");
+    const agendaSomethingElseText = document.getElementById("agenda-something-else-text");
+    const agendaNothingOption = document.getElementById("agenda-nothing-option");
     const inviteModal = document.getElementById("invite-modal");
     const inviteEmailInput = document.getElementById("invite-email-input");
     const inviteFirstNameInput = document.getElementById("invite-first-name-input");
@@ -328,6 +389,7 @@ end %>
     const invitePreviewModal = document.getElementById("invite-preview-modal");
     const invitePreviewBody = document.getElementById("invite-preview-body");
     const invitePreviewClose = document.getElementById("invite-preview-close");
+    let selfRegistrationReadyToSubmit = false;
 
     const closeSelfRegistrationModal = () => {
       if (!selfRegistrationModal) {
@@ -352,6 +414,26 @@ end %>
       }
 
       selfRegistrationModal.hidden = false;
+    };
+
+    const closeAgendaReservationModal = () => {
+      if (!agendaReservationModal) {
+        return;
+      }
+
+      agendaReservationModal.hidden = true;
+    };
+
+    const openAgendaReservationModal = () => {
+      if (!agendaReservationModal) {
+        return;
+      }
+
+      if (agendaReservationError) {
+        agendaReservationError.hidden = true;
+      }
+
+      agendaReservationModal.hidden = false;
     };
 
     const closeInviteModal = () => {
@@ -442,17 +524,26 @@ ${signedInUserName}`;
     selfRegistrationCancel?.addEventListener("click", closeSelfRegistrationModal);
     selfRegistrationRemoveCancel?.addEventListener("click", closeSelfRegistrationModal);
     selfRegistrationForm?.addEventListener("submit", (event) => {
+      if (selfRegistrationReadyToSubmit) {
+        selfRegistrationReadyToSubmit = false;
+        return;
+      }
+
       if (attendancePhysicalOption?.checked) {
         if (attendanceModeValue) {
           attendanceModeValue.value = "physical";
         }
-
-        return;
       }
-
-      if (attendanceOnlineOption?.checked) {
+      else if (attendanceOnlineOption?.checked) {
         if (attendanceModeValue) {
           attendanceModeValue.value = "online";
+        }
+      }
+      else {
+        event.preventDefault();
+
+        if (selfRegistrationError) {
+          selfRegistrationError.hidden = false;
         }
 
         return;
@@ -461,8 +552,37 @@ ${signedInUserName}`;
       event.preventDefault();
 
       if (selfRegistrationError) {
-        selfRegistrationError.hidden = false;
+        selfRegistrationError.hidden = true;
       }
+
+      closeSelfRegistrationModal();
+      openAgendaReservationModal();
+    });
+
+    agendaReservationCancel?.addEventListener("click", closeAgendaReservationModal);
+    agendaReservationContinue?.addEventListener("click", () => {
+      const selectedAgendaOptions = [
+        agendaPresentOption,
+        agendaQuestionOption,
+        agendaSomethingElseOption,
+        agendaNothingOption
+      ].some((option) => option?.checked);
+
+      if (!selectedAgendaOptions) {
+        if (agendaReservationError) {
+          agendaReservationError.hidden = false;
+        }
+
+        return;
+      }
+
+      if (agendaReservationError) {
+        agendaReservationError.hidden = true;
+      }
+
+      closeAgendaReservationModal();
+      selfRegistrationReadyToSubmit = true;
+      selfRegistrationForm?.requestSubmit();
     });
 
     inviteModalCancel?.addEventListener("click", closeInviteModal);
@@ -490,6 +610,12 @@ ${signedInUserName}`;
     selfRegistrationModal?.addEventListener("click", (event) => {
       if (event.target === selfRegistrationModal) {
         closeSelfRegistrationModal();
+      }
+    });
+
+    agendaReservationModal?.addEventListener("click", (event) => {
+      if (event.target === agendaReservationModal) {
+        closeAgendaReservationModal();
       }
     });
 

--- a/db/migrate/20260311123000_add_registration_details_to_registrations.rb
+++ b/db/migrate/20260311123000_add_registration_details_to_registrations.rb
@@ -1,0 +1,12 @@
+class AddRegistrationDetailsToRegistrations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :registrations, :agenda_present, :boolean, null: false, default: false
+    add_column :registrations, :agenda_question, :boolean, null: false, default: false
+    add_column :registrations, :agenda_something_else, :boolean, null: false, default: false
+    add_column :registrations, :agenda_something_else_text, :text
+    add_column :registrations, :agenda_nothing_to_present, :boolean, null: false, default: false
+    add_column :registrations, :has_dietary_requirements, :boolean, null: false, default: false
+    add_column :registrations, :dietary_requirements_text, :text
+    add_column :registrations, :chair_note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_11_110000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_11_123000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -74,9 +74,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_110000) do
   end
 
   create_table "registrations", force: :cascade do |t|
+    t.boolean "agenda_nothing_to_present", default: false, null: false
+    t.boolean "agenda_present", default: false, null: false
+    t.boolean "agenda_question", default: false, null: false
+    t.boolean "agenda_something_else", default: false, null: false
+    t.text "agenda_something_else_text"
     t.boolean "attending_physically", null: false
+    t.text "chair_note"
     t.bigint "conference_id", null: false
     t.datetime "created_at", null: false
+    t.text "dietary_requirements_text"
+    t.boolean "has_dietary_requirements", default: false, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["conference_id"], name: "index_registrations_on_conference_id"

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -15,13 +15,31 @@ class RegistrationsControllerTest < ActionController::TestCase
     session[:user_id] = @user.id
 
     assert_difference("Registration.count", 1) do
-      post :create, params: { registration: { attendance_mode: "physical" } }
+      post :create, params: {
+        registration: {
+          attendance_mode: "physical",
+          agenda_present: "1",
+          agenda_question: "0",
+          agenda_something_else: "1",
+          agenda_something_else_text: "Open discussion about routes",
+          agenda_nothing_to_present: "0",
+          has_dietary_requirements: "1",
+          dietary_requirements_text: "Vegetarian",
+          chair_note: "A visa letter may be needed."
+        }
+      }
     end
 
     registration = Registration.last
     assert_equal @user, registration.user
     assert_equal @conference, registration.conference
     assert registration.attending_physically?
+    assert registration.agenda_present?
+    assert registration.agenda_something_else?
+    assert_equal "Open discussion about routes", registration.agenda_something_else_text
+    assert registration.has_dietary_requirements?
+    assert_equal "Vegetarian", registration.dietary_requirements_text
+    assert_equal "A visa letter may be needed.", registration.chair_note
     assert_redirected_to root_url
   end
 
@@ -29,7 +47,7 @@ class RegistrationsControllerTest < ActionController::TestCase
     session[:user_id] = @user.id
 
     assert_no_difference("Registration.count") do
-      post :create, params: { registration: { attendance_mode: "" } }
+      post :create, params: { registration: { attendance_mode: "", agenda_present: "1" } }
     end
 
     assert_redirected_to root_url
@@ -37,7 +55,12 @@ class RegistrationsControllerTest < ActionController::TestCase
 
   test "should remove an existing registration" do
     session[:user_id] = @user.id
-    registration = Registration.create!(user: @user, conference: @conference, attending_physically: false)
+    registration = Registration.create!(
+      user: @user,
+      conference: @conference,
+      attending_physically: false,
+      agenda_nothing_to_present: true
+    )
 
     assert_difference("Registration.count", -1) do
       delete :destroy

--- a/test/models/registration_test.rb
+++ b/test/models/registration_test.rb
@@ -15,24 +15,46 @@ class RegistrationTest < ActiveSupport::TestCase
     registration = Registration.new(
       user: @user,
       conference: @conference,
-      attending_physically: true
+      attending_physically: true,
+      agenda_present: true
     )
 
     assert registration.valid?
   end
 
   test "registration requires the physical attendance flag" do
-    registration = Registration.new(user: @user, conference: @conference)
+    registration = Registration.new(user: @user, conference: @conference, agenda_present: true)
 
     assert_not registration.valid?
     assert_includes registration.errors[:attending_physically], "is not included in the list"
   end
 
   test "user can only register once per conference" do
-    Registration.create!(user: @user, conference: @conference, attending_physically: true)
-    duplicate = Registration.new(user: @user, conference: @conference, attending_physically: false)
+    Registration.create!(user: @user, conference: @conference, attending_physically: true, agenda_present: true)
+    duplicate = Registration.new(user: @user, conference: @conference, attending_physically: false, agenda_question: true)
 
     assert_not duplicate.valid?
     assert_includes duplicate.errors[:user_id], "has already been taken"
+  end
+
+  test "registration requires at least one agenda option" do
+    registration = Registration.new(user: @user, conference: @conference, attending_physically: true)
+
+    assert_not registration.valid?
+    assert_includes registration.errors[:base], "Select at least one agenda option"
+  end
+
+  test "dietary requirements need details when selected" do
+    registration = Registration.new(
+      user: @user,
+      conference: @conference,
+      attending_physically: true,
+      agenda_present: true,
+      has_dietary_requirements: true,
+      dietary_requirements_text: "Please specify"
+    )
+
+    assert_not registration.valid?
+    assert_includes registration.errors[:dietary_requirements_text], "must be provided when dietary requirements are selected"
   end
 end


### PR DESCRIPTION
## Summary
- hook the registration modals into the controller so agenda choices, dietary details, and chair notes are saved with the registration
- require at least one agenda option plus dietary text when "Yes" is picked and strip placeholder text before saving
- add the migration/schema changes and tests that cover the new validation and controller behavior

## Testing
- Not run (not requested)