### PR TITLE
Add invitation workflow for conference invites

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,37 @@
+class InvitationsController < ApplicationController
+  before_action :require_login
+  before_action :set_current_conference
+
+  def create
+    invitation = current_user.sent_invitations.build(invitation_params.merge(conference: @conference))
+
+    if invitation.save
+      body = helpers.invitation_email_body(invitation, token: invitation.raw_token)
+
+      EmailDeliveryService.notify(
+        to: invitation.email,
+        subject: helpers.invitation_email_subject(@conference),
+        body: body
+      )
+
+      flash[:invitation_email_body] = body
+      redirect_to root_path, notice: "Invitation prepared for #{invitation.email}."
+    else
+      redirect_to root_path, alert: invitation.errors.full_messages.to_sentence
+    end
+  end
+
+  private
+
+  def set_current_conference
+    @conference = Conference.find_by(current: true)
+
+    return if @conference.present?
+
+    redirect_to root_path, alert: "There is no current conference open for registration."
+  end
+
+  def invitation_params
+    params.require(:invitation).permit(:first_name, :email)
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,7 @@ class PagesController < ApplicationController
     @current_conference = Conference.find_by(current: true)
     @current_registration = current_user&.registrations&.find_by(conference: @current_conference)
     @registration_confirmation = current_user&.registrations&.find_by(id: flash[:registration_confirmation_id])
+    @invitation_email_body = flash[:invitation_email_body]
     @conferences = Conference.all.order(:start_date)
     @schedules = Schedule.order(:day, :time)
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,9 @@
 class PagesController < ApplicationController
   def landing
     @invitation_token_supplied = params[:invitation_token].present?
-    @invitation_token_valid = validate_invitation_token(params[:invitation_token]) if @invitation_token_supplied
+    @invitation = find_valid_invitation(params[:invitation_token]) if @invitation_token_supplied
+    @invitation_token_valid = @invitation.present?
+    @invited_user_exists = User.exists?(email: @invitation.email) if @invitation_token_valid
 
     return if @invitation_token_supplied
 
@@ -15,8 +17,8 @@ class PagesController < ApplicationController
 
   private
 
-  def validate_invitation_token(token)
+  def find_valid_invitation(token)
     invitation = Invitation.find_by_token(token)
-    invitation&.usable? || false
+    invitation if invitation&.usable?
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -10,11 +10,12 @@ class PagesController < ApplicationController
     @invitation_email_body = flash[:invitation_email_body]
     @conferences = Conference.all.order(:start_date)
     @schedules = Schedule.order(:day, :time)
-    @show_already_registered_invitation_popup = show_already_registered_invitation_popup?
-    consume_invitation! if @show_already_registered_invitation_popup
+    @show_known_user_invitation_popup = show_known_user_invitation_popup?
+    @known_user_invitation_popup_message = known_user_invitation_popup_message
+    consume_invitation! if @show_known_user_invitation_popup
 
     return unless @invitation_token_supplied
-    return if @show_already_registered_invitation_popup
+    return if @show_known_user_invitation_popup
 
     @current_conference = nil
     @current_registration = nil
@@ -40,8 +41,18 @@ class PagesController < ApplicationController
     @invited_user_registered_for_current_conference = @current_conference.present? && @invited_user.registrations.exists?(conference: @current_conference)
   end
 
-  def show_already_registered_invitation_popup?
-    @invitation_token_valid && @invited_user_exists && @invited_user_registered_for_current_conference
+  def show_known_user_invitation_popup?
+    @invitation_token_valid && @invited_user_exists
+  end
+
+  def known_user_invitation_popup_message
+    return unless @show_known_user_invitation_popup
+
+    if @invited_user_registered_for_current_conference
+      "You are already registered for FMUG #{@current_conference.edition}"
+    else
+      "Welcome back #{@invited_user.first_name}, you are not yet registered for the upcoming FMUG"
+    end
   end
 
   def consume_invitation!

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,10 +1,22 @@
 class PagesController < ApplicationController
   def landing
+    @invitation_token_supplied = params[:invitation_token].present?
+    @invitation_token_valid = validate_invitation_token(params[:invitation_token]) if @invitation_token_supplied
+
+    return if @invitation_token_supplied
+
     @current_conference = Conference.find_by(current: true)
     @current_registration = current_user&.registrations&.find_by(conference: @current_conference)
     @registration_confirmation = current_user&.registrations&.find_by(id: flash[:registration_confirmation_id])
     @invitation_email_body = flash[:invitation_email_body]
     @conferences = Conference.all.order(:start_date)
     @schedules = Schedule.order(:day, :time)
+  end
+
+  private
+
+  def validate_invitation_token(token)
+    invitation = Invitation.find_by_token(token)
+    invitation&.usable? || false
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,7 @@ class PagesController < ApplicationController
     @invitation_token_supplied = params[:invitation_token].present?
     @invitation = find_valid_invitation(params[:invitation_token]) if @invitation_token_supplied
     @invitation_token_valid = @invitation.present?
-    @invited_user_exists = User.exists?(email: @invitation.email) if @invitation_token_valid
+    set_invited_user_state if @invitation_token_valid
 
     return if @invitation_token_supplied
 
@@ -20,5 +20,14 @@ class PagesController < ApplicationController
   def find_valid_invitation(token)
     invitation = Invitation.find_by_token(token)
     invitation if invitation&.usable?
+  end
+
+  def set_invited_user_state
+    @invited_user = User.find_by(email: @invitation.email)
+    @invited_user_exists = @invited_user.present?
+    return unless @invited_user_exists
+
+    @current_conference = Conference.find_by(current: true)
+    @invited_user_registered_for_current_conference = @current_conference.present? && @invited_user.registrations.exists?(conference: @current_conference)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,11 +11,12 @@ class PagesController < ApplicationController
     @conferences = Conference.all.order(:start_date)
     @schedules = Schedule.order(:day, :time)
     @show_known_user_invitation_popup = show_known_user_invitation_popup?
+    @show_new_user_invitation_popup = show_new_user_invitation_popup?
     @known_user_invitation_popup_message = known_user_invitation_popup_message
     consume_invitation! if @show_known_user_invitation_popup
 
     return unless @invitation_token_supplied
-    return if @show_known_user_invitation_popup
+    return if @show_known_user_invitation_popup || @show_new_user_invitation_popup
 
     @current_conference = nil
     @current_registration = nil
@@ -43,6 +44,10 @@ class PagesController < ApplicationController
 
   def show_known_user_invitation_popup?
     @invitation_token_valid && @invited_user_exists
+  end
+
+  def show_new_user_invitation_popup?
+    @invitation_token_valid && !@invited_user_exists
   end
 
   def known_user_invitation_popup_message

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,15 +4,24 @@ class PagesController < ApplicationController
     @invitation = find_valid_invitation(params[:invitation_token]) if @invitation_token_supplied
     @invitation_token_valid = @invitation.present?
     set_invited_user_state if @invitation_token_valid
-
-    return if @invitation_token_supplied
-
     @current_conference = Conference.find_by(current: true)
     @current_registration = current_user&.registrations&.find_by(conference: @current_conference)
     @registration_confirmation = current_user&.registrations&.find_by(id: flash[:registration_confirmation_id])
     @invitation_email_body = flash[:invitation_email_body]
     @conferences = Conference.all.order(:start_date)
     @schedules = Schedule.order(:day, :time)
+    @show_already_registered_invitation_popup = show_already_registered_invitation_popup?
+    consume_invitation! if @show_already_registered_invitation_popup
+
+    return unless @invitation_token_supplied
+    return if @show_already_registered_invitation_popup
+
+    @current_conference = nil
+    @current_registration = nil
+    @registration_confirmation = nil
+    @invitation_email_body = nil
+    @conferences = nil
+    @schedules = nil
   end
 
   private
@@ -29,5 +38,15 @@ class PagesController < ApplicationController
 
     @current_conference = Conference.find_by(current: true)
     @invited_user_registered_for_current_conference = @current_conference.present? && @invited_user.registrations.exists?(conference: @current_conference)
+  end
+
+  def show_already_registered_invitation_popup?
+    @invitation_token_valid && @invited_user_exists && @invited_user_registered_for_current_conference
+  end
+
+  def consume_invitation!
+    return unless @invitation&.used_at.nil?
+
+    @invitation.mark_as_used!
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,4 +36,36 @@ module ApplicationHelper
       "The Chair"
     ].compact.join("\n")
   end
+
+  def invitation_email_subject(conference)
+    "Invitation to Conference #{conference.edition}"
+  end
+
+  def invitation_email_body(invitation, token:)
+    conference = invitation.conference
+    inviter_name = [ invitation.inviter.first_name, invitation.inviter.last_name ].compact.join(" ").presence || invitation.inviter.email
+    invitation_link = root_url(invitation_token: token)
+
+    [
+      "Hi #{invitation.first_name},",
+      "",
+      "#{inviter_name} invited you to join Conference #{conference.edition}.",
+      "",
+      "Conference dates: #{conference.start_date.strftime("%b %-d, %Y")} - #{conference.end_date.strftime("%b %-d, %Y")}",
+      "Location: #{conference.location}",
+      "",
+      "Invitation token: #{token}",
+      "",
+      "Use this invitation link to register:",
+      invitation_link,
+      "",
+      "This invitation expires on #{invitation.expires_at.strftime("%b %-d, %Y at %H:%M %Z")}.",
+      "It can only be used once.",
+      "",
+      "This is placeholder text for the invitation email body. We will replace this draft with the real conference details later.",
+      "",
+      "Best regards,",
+      inviter_name
+    ].join("\n")
+  end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,0 +1,59 @@
+class Invitation < ApplicationRecord
+  EXPIRATION_PERIOD = 7.days
+
+  belongs_to :conference
+  belongs_to :inviter, class_name: "User"
+
+  attr_reader :raw_token
+
+  before_validation :normalize_attributes
+  before_validation :assign_token, on: :create
+  before_validation :assign_expiration, on: :create
+
+  validates :email, :first_name, :token_digest, :expires_at, presence: true
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :token_digest, uniqueness: true
+
+  scope :active, -> { where(used_at: nil).where("expires_at > ?", Time.current) }
+
+  def expired?
+    expires_at <= Time.current
+  end
+
+  def usable?
+    used_at.nil? && !expired?
+  end
+
+  def mark_as_used!
+    update!(used_at: Time.current)
+  end
+
+  def self.find_by_token(token)
+    find_by(token_digest: digest(token))
+  end
+
+  def self.digest(token)
+    Digest::SHA256.hexdigest(token.to_s)
+  end
+
+  private
+
+  def normalize_attributes
+    self.first_name = first_name.to_s.strip
+    self.email = email.to_s.strip.downcase
+  end
+
+  def assign_token
+    return if token_digest.present?
+
+    loop do
+      @raw_token = SecureRandom.urlsafe_base64(32)
+      self.token_digest = self.class.digest(@raw_token)
+      break unless self.class.exists?(token_digest: token_digest)
+    end
+  end
+
+  def assign_expiration
+    self.expires_at ||= EXPIRATION_PERIOD.from_now
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,6 @@ class User < ApplicationRecord
   has_many :sent_invitations, class_name: "Invitation", foreign_key: :inviter_id, dependent: :destroy
   has_many :conferences, through: :registrations
 
-  validates :email, :first_name, :last_name, :role, presence: true
+  validates :email, :first_name, :last_name, presence: true
   validates :email, uniqueness: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   belongs_to :company, optional: true
   has_many :identities, dependent: :destroy
   has_many :registrations, dependent: :destroy
+  has_many :sent_invitations, class_name: "Invitation", foreign_key: :inviter_id, dependent: :destroy
   has_many :conferences, through: :registrations
 
   validates :email, :first_name, :last_name, :role, presence: true

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -218,7 +218,7 @@ end %>
   }
 </style>
 
-<% if @invitation_token_supplied && !@show_already_registered_invitation_popup %>
+<% if @invitation_token_supplied && !@show_known_user_invitation_popup %>
   <div class="fixed inset-0 flex items-center justify-center px-6">
     <div class="rounded-3xl border border-stone-200 bg-white px-8 py-10 text-center text-3xl font-semibold text-stone-900 shadow-sm whitespace-pre-line">
       <%= @invitation_token_valid ? "Token validated and still valid" : "Invalid invitation token" %>
@@ -264,13 +264,13 @@ end %>
   </div>
 </div>
 
-<% if @show_already_registered_invitation_popup %>
-  <div id="already-registered-invitation-modal" class="registration-modal" hidden>
-    <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="already-registered-invitation-title">
-      <h2 id="already-registered-invitation-title" class="registration-modal__title">Registration status</h2>
-      <div class="registration-modal__draft">You are already registered for FMUG <%= @current_conference.edition %></div>
+<% if @show_known_user_invitation_popup %>
+  <div id="known-user-invitation-modal" class="registration-modal" hidden>
+    <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="known-user-invitation-title">
+      <h2 id="known-user-invitation-title" class="registration-modal__title">Registration status</h2>
+      <div class="registration-modal__draft"><%= @known_user_invitation_popup_message %></div>
       <div class="registration-modal__actions">
-        <button type="button" id="already-registered-invitation-close" class="landing-auth__button">Close</button>
+        <button type="button" id="known-user-invitation-close" class="landing-auth__button">Close</button>
       </div>
     </div>
   </div>
@@ -529,8 +529,8 @@ end %>
     const chairNoteValue = document.getElementById("chair-note-value");
     const registrationConfirmationModal = document.getElementById("registration-confirmation-modal");
     const registrationConfirmationClose = document.getElementById("registration-confirmation-close");
-    const alreadyRegisteredInvitationModal = document.getElementById("already-registered-invitation-modal");
-    const alreadyRegisteredInvitationClose = document.getElementById("already-registered-invitation-close");
+    const knownUserInvitationModal = document.getElementById("known-user-invitation-modal");
+    const knownUserInvitationClose = document.getElementById("known-user-invitation-close");
     const inviteModal = document.getElementById("invite-modal");
     const inviteForm = document.getElementById("invite-form");
     const inviteEmailInput = document.getElementById("invite-email-input");
@@ -632,20 +632,20 @@ end %>
       registrationConfirmationModal.hidden = true;
     };
 
-    const closeAlreadyRegisteredInvitationModal = () => {
-      if (!alreadyRegisteredInvitationModal) {
+    const closeKnownUserInvitationModal = () => {
+      if (!knownUserInvitationModal) {
         return;
       }
 
-      alreadyRegisteredInvitationModal.hidden = true;
+      knownUserInvitationModal.hidden = true;
     };
 
-    const openAlreadyRegisteredInvitationModal = () => {
-      if (!alreadyRegisteredInvitationModal) {
+    const openKnownUserInvitationModal = () => {
+      if (!knownUserInvitationModal) {
         return;
       }
 
-      alreadyRegisteredInvitationModal.hidden = false;
+      knownUserInvitationModal.hidden = false;
     };
 
     const removeInvitationTokenFromUrl = () => {
@@ -881,7 +881,7 @@ end %>
       selfRegistrationForm?.requestSubmit();
     });
     registrationConfirmationClose?.addEventListener("click", closeRegistrationConfirmationModal);
-    alreadyRegisteredInvitationClose?.addEventListener("click", closeAlreadyRegisteredInvitationModal);
+    knownUserInvitationClose?.addEventListener("click", closeKnownUserInvitationModal);
 
     inviteModalCancel?.addEventListener("click", closeInviteModal);
     inviteForm?.addEventListener("submit", (event) => {
@@ -908,9 +908,9 @@ end %>
       openInvitePreviewModal();
     }
 
-    if (alreadyRegisteredInvitationModal) {
+    if (knownUserInvitationModal) {
       removeInvitationTokenFromUrl();
-      openAlreadyRegisteredInvitationModal();
+      openKnownUserInvitationModal();
     }
 
     selfRegistrationModal?.addEventListener("click", (event) => {
@@ -943,9 +943,9 @@ end %>
       }
     });
 
-    alreadyRegisteredInvitationModal?.addEventListener("click", (event) => {
-      if (event.target === alreadyRegisteredInvitationModal) {
-        closeAlreadyRegisteredInvitationModal();
+    knownUserInvitationModal?.addEventListener("click", (event) => {
+      if (event.target === knownUserInvitationModal) {
+        closeKnownUserInvitationModal();
       }
     });
 

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -220,8 +220,11 @@ end %>
 
 <% if @invitation_token_supplied %>
   <div class="fixed inset-0 flex items-center justify-center px-6">
-    <div class="rounded-3xl border border-stone-200 bg-white px-8 py-10 text-center text-3xl font-semibold text-stone-900 shadow-sm">
+    <div class="rounded-3xl border border-stone-200 bg-white px-8 py-10 text-center text-3xl font-semibold text-stone-900 shadow-sm whitespace-pre-line">
       <%= @invitation_token_valid ? "Token validated and still valid" : "Invalid invitation token" %>
+      <% if @invitation_token_valid %>
+<%= @invited_user_exists ? "you're already a user" : "welcome new user" %>
+      <% end %>
     </div>
   </div>
 <% else %>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -218,7 +218,7 @@ end %>
   }
 </style>
 
-<% if @invitation_token_supplied && !@show_known_user_invitation_popup %>
+<% if @invitation_token_supplied && !@show_known_user_invitation_popup && !@show_new_user_invitation_popup %>
   <div class="fixed inset-0 flex items-center justify-center px-6">
     <div class="rounded-3xl border border-stone-200 bg-white px-8 py-10 text-center text-3xl font-semibold text-stone-900 shadow-sm whitespace-pre-line">
       <%= @invitation_token_valid ? "Token validated and still valid" : "Invalid invitation token" %>
@@ -271,6 +271,42 @@ end %>
       <div class="registration-modal__draft"><%= @known_user_invitation_popup_message %></div>
       <div class="registration-modal__actions">
         <button type="button" id="known-user-invitation-close" class="landing-auth__button">Close</button>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<% if @show_new_user_invitation_popup %>
+  <div id="new-user-invitation-modal" class="registration-modal" hidden>
+    <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="new-user-invitation-title">
+      <h2 id="new-user-invitation-title" class="registration-modal__title">Complete your FMUG profile</h2>
+      <p class="registration-modal__copy">Please provide your details to prepare your user account.</p>
+
+      <div class="mt-5 text-left">
+        <label class="invite-modal__field" for="new-user-invitation-email">
+          Email address
+          <input
+            id="new-user-invitation-email"
+            class="invite-modal__input"
+            type="email"
+            value="<%= @invitation.email %>"
+            readonly
+          />
+        </label>
+
+        <label class="invite-modal__field" for="new-user-invitation-first-name">
+          First name
+          <input id="new-user-invitation-first-name" class="invite-modal__input" type="text" autocomplete="given-name" />
+        </label>
+
+        <label class="invite-modal__field" for="new-user-invitation-last-name">
+          Last name
+          <input id="new-user-invitation-last-name" class="invite-modal__input" type="text" autocomplete="family-name" />
+        </label>
+      </div>
+
+      <div class="registration-modal__actions">
+        <button type="button" id="new-user-invitation-close" class="landing-auth__button">Close</button>
       </div>
     </div>
   </div>
@@ -531,6 +567,8 @@ end %>
     const registrationConfirmationClose = document.getElementById("registration-confirmation-close");
     const knownUserInvitationModal = document.getElementById("known-user-invitation-modal");
     const knownUserInvitationClose = document.getElementById("known-user-invitation-close");
+    const newUserInvitationModal = document.getElementById("new-user-invitation-modal");
+    const newUserInvitationClose = document.getElementById("new-user-invitation-close");
     const inviteModal = document.getElementById("invite-modal");
     const inviteForm = document.getElementById("invite-form");
     const inviteEmailInput = document.getElementById("invite-email-input");
@@ -646,6 +684,22 @@ end %>
       }
 
       knownUserInvitationModal.hidden = false;
+    };
+
+    const closeNewUserInvitationModal = () => {
+      if (!newUserInvitationModal) {
+        return;
+      }
+
+      newUserInvitationModal.hidden = true;
+    };
+
+    const openNewUserInvitationModal = () => {
+      if (!newUserInvitationModal) {
+        return;
+      }
+
+      newUserInvitationModal.hidden = false;
     };
 
     const removeInvitationTokenFromUrl = () => {
@@ -882,6 +936,7 @@ end %>
     });
     registrationConfirmationClose?.addEventListener("click", closeRegistrationConfirmationModal);
     knownUserInvitationClose?.addEventListener("click", closeKnownUserInvitationModal);
+    newUserInvitationClose?.addEventListener("click", closeNewUserInvitationModal);
 
     inviteModalCancel?.addEventListener("click", closeInviteModal);
     inviteForm?.addEventListener("submit", (event) => {
@@ -908,9 +963,16 @@ end %>
       openInvitePreviewModal();
     }
 
-    if (knownUserInvitationModal) {
+    if (knownUserInvitationModal || newUserInvitationModal) {
       removeInvitationTokenFromUrl();
+    }
+
+    if (knownUserInvitationModal) {
       openKnownUserInvitationModal();
+    }
+
+    if (newUserInvitationModal) {
+      openNewUserInvitationModal();
     }
 
     selfRegistrationModal?.addEventListener("click", (event) => {
@@ -946,6 +1008,12 @@ end %>
     knownUserInvitationModal?.addEventListener("click", (event) => {
       if (event.target === knownUserInvitationModal) {
         closeKnownUserInvitationModal();
+      }
+    });
+
+    newUserInvitationModal?.addEventListener("click", (event) => {
+      if (event.target === newUserInvitationModal) {
+        closeNewUserInvitationModal();
       }
     });
 

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -415,31 +415,37 @@ end %>
     <h2 id="invite-modal-title" class="invite-modal__title">Invite attendee</h2>
     <p class="invite-modal__copy">Enter the first name and email address for the invitation.</p>
 
-    <label class="invite-modal__field" for="invite-first-name-input">
-      First name
-      <input id="invite-first-name-input" class="invite-modal__input" type="text" autocomplete="given-name" required />
-    </label>
+    <%= form_with scope: :invitation, url: invitations_path, method: :post, local: true, id: "invite-form" do |form| %>
+      <label class="invite-modal__field" for="invite-first-name-input">
+        First name
+        <%= form.text_field :first_name, id: "invite-first-name-input", class: "invite-modal__input", autocomplete: "given-name", required: true %>
+      </label>
 
-    <label class="invite-modal__field" for="invite-email-input">
-      Email address
-      <input id="invite-email-input" class="invite-modal__input" type="email" autocomplete="email" required />
-    </label>
+      <label class="invite-modal__field" for="invite-email-input">
+        Email address
+        <%= form.email_field :email, id: "invite-email-input", class: "invite-modal__input", autocomplete: "email", required: true %>
+      </label>
 
-    <p id="invite-modal-error" class="invite-modal__error" hidden>Please enter both the first name and email address before continuing.</p>
+      <p id="invite-modal-error" class="invite-modal__error" hidden>Please enter both the first name and email address before continuing.</p>
 
-    <div class="invite-modal__actions">
-      <button type="button" id="invite-modal-cancel" class="landing-auth__button">Cancel</button>
-      <button type="button" id="invite-modal-save" class="landing-auth__button">Continue</button>
-    </div>
+      <div class="invite-modal__actions">
+        <button type="button" id="invite-modal-cancel" class="landing-auth__button">Cancel</button>
+        <button type="submit" id="invite-modal-save" class="landing-auth__button">Continue</button>
+      </div>
+    <% end %>
   </div>
 </div>
 
-<div id="invite-preview-modal" class="invite-modal" hidden>
+<div id="invite-preview-modal" class="invite-modal" <%= "hidden" unless @invitation_email_body.present? %>>
   <div class="invite-modal__panel" role="dialog" aria-modal="true" aria-labelledby="invite-preview-title">
-    <h2 id="invite-preview-title" class="invite-modal__title">Invitation draft</h2>
+    <h2 id="invite-preview-title" class="invite-modal__title">Invitation email</h2>
     <p class="invite-modal__copy">Preview of the email that would be sent.</p>
 
-    <div id="invite-preview-body" class="invite-modal__draft"></div>
+    <% if @invitation_email_body.present? %>
+      <div id="invite-preview-body" class="invite-modal__draft"><%= @invitation_email_body %></div>
+    <% else %>
+      <div id="invite-preview-body" class="invite-modal__draft"></div>
+    <% end %>
 
     <div class="invite-modal__actions">
       <button type="button" id="invite-preview-close" class="landing-auth__button">Close</button>
@@ -450,7 +456,6 @@ end %>
 <script>
   document.addEventListener("DOMContentLoaded", () => {
     const alreadyRegistered = <%= @current_registration.present? ? "true" : "false" %>;
-    const signedInUserName = "<%= j([current_user&.first_name, current_user&.last_name].compact.join(" ").presence || current_user&.email.to_s) %>";
     const registerButton = document.getElementById("register-button");
     const registerSection = document.getElementById("register-section");
     const registerSelfOption = document.getElementById("register-self-option");
@@ -500,6 +505,7 @@ end %>
     const registrationConfirmationModal = document.getElementById("registration-confirmation-modal");
     const registrationConfirmationClose = document.getElementById("registration-confirmation-close");
     const inviteModal = document.getElementById("invite-modal");
+    const inviteForm = document.getElementById("invite-form");
     const inviteEmailInput = document.getElementById("invite-email-input");
     const inviteFirstNameInput = document.getElementById("invite-first-name-input");
     const inviteModalError = document.getElementById("invite-modal-error");
@@ -629,19 +635,10 @@ end %>
       invitePreviewModal.hidden = true;
     };
 
-    const openInvitePreviewModal = (invitedFirstName) => {
+    const openInvitePreviewModal = () => {
       if (!invitePreviewModal || !invitePreviewBody) {
         return;
       }
-
-      invitePreviewBody.textContent = `Hi ${invitedFirstName},
-
-I would like to invite you to join the upcoming FMUG conference.
-
-This is placeholder text for the invitation email body. We will replace this draft with the real conference details later.
-
-Best regards,
-${signedInUserName}`;
 
       invitePreviewModal.hidden = false;
     };
@@ -831,11 +828,13 @@ ${signedInUserName}`;
     registrationConfirmationClose?.addEventListener("click", closeRegistrationConfirmationModal);
 
     inviteModalCancel?.addEventListener("click", closeInviteModal);
-    inviteModalSave?.addEventListener("click", () => {
+    inviteForm?.addEventListener("submit", (event) => {
       const invitedFirstName = inviteFirstNameInput?.value.trim();
       const invitedEmail = inviteEmailInput?.value.trim();
 
       if (!invitedFirstName || !invitedEmail) {
+        event.preventDefault();
+
         if (inviteModalError) {
           inviteModalError.hidden = false;
         }
@@ -846,11 +845,12 @@ ${signedInUserName}`;
       if (inviteModalError) {
         inviteModalError.hidden = true;
       }
-
-      closeInviteModal();
-      openInvitePreviewModal(invitedFirstName);
     });
     invitePreviewClose?.addEventListener("click", closeInvitePreviewModal);
+
+    if (!invitePreviewModal?.hidden) {
+      openInvitePreviewModal();
+    }
 
     selfRegistrationModal?.addEventListener("click", (event) => {
       if (event.target === selfRegistrationModal) {

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -224,6 +224,9 @@ end %>
       <%= @invitation_token_valid ? "Token validated and still valid" : "Invalid invitation token" %>
       <% if @invitation_token_valid %>
 <%= @invited_user_exists ? "you're already a user" : "welcome new user" %>
+        <% if @invited_user_exists %>
+<%= @invited_user_registered_for_current_conference ? "you are already registered for FMUG ##{@current_conference.edition}" : "you're not registered for the upcoming FMUG" %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -218,6 +218,13 @@ end %>
   }
 </style>
 
+<% if @invitation_token_supplied %>
+  <div class="fixed inset-0 flex items-center justify-center px-6">
+    <div class="rounded-3xl border border-stone-200 bg-white px-8 py-10 text-center text-3xl font-semibold text-stone-900 shadow-sm">
+      <%= @invitation_token_valid ? "Token validated and still valid" : "Invalid invitation token" %>
+    </div>
+  </div>
+<% else %>
 <div class="flex w-full flex-col space-y-8">
   <div class="landing-auth">
     <% if logged_in? %>
@@ -895,3 +902,4 @@ end %>
     });
   });
 </script>
+<% end %>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -218,7 +218,7 @@ end %>
   }
 </style>
 
-<% if @invitation_token_supplied %>
+<% if @invitation_token_supplied && !@show_already_registered_invitation_popup %>
   <div class="fixed inset-0 flex items-center justify-center px-6">
     <div class="rounded-3xl border border-stone-200 bg-white px-8 py-10 text-center text-3xl font-semibold text-stone-900 shadow-sm whitespace-pre-line">
       <%= @invitation_token_valid ? "Token validated and still valid" : "Invalid invitation token" %>
@@ -263,6 +263,18 @@ end %>
 
   </div>
 </div>
+
+<% if @show_already_registered_invitation_popup %>
+  <div id="already-registered-invitation-modal" class="registration-modal" hidden>
+    <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="already-registered-invitation-title">
+      <h2 id="already-registered-invitation-title" class="registration-modal__title">Registration status</h2>
+      <div class="registration-modal__draft">You are already registered for FMUG <%= @current_conference.edition %></div>
+      <div class="registration-modal__actions">
+        <button type="button" id="already-registered-invitation-close" class="landing-auth__button">Close</button>
+      </div>
+    </div>
+  </div>
+<% end %>
 
 <div id="self-registration-modal" class="registration-modal" hidden>
   <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="self-registration-title">
@@ -517,6 +529,8 @@ end %>
     const chairNoteValue = document.getElementById("chair-note-value");
     const registrationConfirmationModal = document.getElementById("registration-confirmation-modal");
     const registrationConfirmationClose = document.getElementById("registration-confirmation-close");
+    const alreadyRegisteredInvitationModal = document.getElementById("already-registered-invitation-modal");
+    const alreadyRegisteredInvitationClose = document.getElementById("already-registered-invitation-close");
     const inviteModal = document.getElementById("invite-modal");
     const inviteForm = document.getElementById("invite-form");
     const inviteEmailInput = document.getElementById("invite-email-input");
@@ -616,6 +630,34 @@ end %>
       }
 
       registrationConfirmationModal.hidden = true;
+    };
+
+    const closeAlreadyRegisteredInvitationModal = () => {
+      if (!alreadyRegisteredInvitationModal) {
+        return;
+      }
+
+      alreadyRegisteredInvitationModal.hidden = true;
+    };
+
+    const openAlreadyRegisteredInvitationModal = () => {
+      if (!alreadyRegisteredInvitationModal) {
+        return;
+      }
+
+      alreadyRegisteredInvitationModal.hidden = false;
+    };
+
+    const removeInvitationTokenFromUrl = () => {
+      const currentUrl = new URL(window.location.href);
+
+      if (!currentUrl.searchParams.has("invitation_token")) {
+        return;
+      }
+
+      currentUrl.searchParams.delete("invitation_token");
+      const sanitizedUrl = `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`;
+      window.history.replaceState({}, document.title, sanitizedUrl);
     };
 
     const closeInviteModal = () => {
@@ -839,6 +881,7 @@ end %>
       selfRegistrationForm?.requestSubmit();
     });
     registrationConfirmationClose?.addEventListener("click", closeRegistrationConfirmationModal);
+    alreadyRegisteredInvitationClose?.addEventListener("click", closeAlreadyRegisteredInvitationModal);
 
     inviteModalCancel?.addEventListener("click", closeInviteModal);
     inviteForm?.addEventListener("submit", (event) => {
@@ -863,6 +906,11 @@ end %>
 
     if (!invitePreviewModal?.hidden) {
       openInvitePreviewModal();
+    }
+
+    if (alreadyRegisteredInvitationModal) {
+      removeInvitationTokenFromUrl();
+      openAlreadyRegisteredInvitationModal();
     }
 
     selfRegistrationModal?.addEventListener("click", (event) => {
@@ -892,6 +940,12 @@ end %>
     registrationConfirmationModal?.addEventListener("click", (event) => {
       if (event.target === registrationConfirmationModal) {
         closeRegistrationConfirmationModal();
+      }
+    });
+
+    alreadyRegisteredInvitationModal?.addEventListener("click", (event) => {
+      if (event.target === alreadyRegisteredInvitationModal) {
+        closeAlreadyRegisteredInvitationModal();
       }
     });
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   resources :schedules
   resources :conferences
+  resources :invitations, only: [ :create ]
   resource :registration, only: [ :create, :destroy ]
   match "/auth/:provider/callback", to: "sessions#create", via: [ :get, :post ]
   match "/auth/failure", to: "sessions#failure", via: [ :get, :post ]

--- a/db/migrate/20260312202732_create_invitations.rb
+++ b/db/migrate/20260312202732_create_invitations.rb
@@ -1,0 +1,18 @@
+class CreateInvitations < ActiveRecord::Migration[8.1]
+  def change
+    create_table :invitations do |t|
+      t.references :conference, null: false, foreign_key: true
+      t.references :inviter, null: false, foreign_key: { to_table: :users }
+      t.string :email, null: false
+      t.string :first_name, null: false
+      t.string :token_digest, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :used_at
+
+      t.timestamps
+    end
+
+    add_index :invitations, :token_digest, unique: true
+    add_index :invitations, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_11_123000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_12_202732) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -73,6 +73,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_123000) do
     t.index ["user_id"], name: "index_identities_on_user_id"
   end
 
+  create_table "invitations", force: :cascade do |t|
+    t.bigint "conference_id", null: false
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.datetime "expires_at", null: false
+    t.string "first_name", null: false
+    t.bigint "inviter_id", null: false
+    t.string "token_digest", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "used_at"
+    t.index ["conference_id"], name: "index_invitations_on_conference_id"
+    t.index ["email"], name: "index_invitations_on_email"
+    t.index ["inviter_id"], name: "index_invitations_on_inviter_id"
+    t.index ["token_digest"], name: "index_invitations_on_token_digest", unique: true
+  end
+
   create_table "registrations", force: :cascade do |t|
     t.boolean "agenda_nothing_to_present", default: false, null: false
     t.boolean "agenda_present", default: false, null: false
@@ -119,6 +135,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_123000) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "identities", "users"
+  add_foreign_key "invitations", "conferences"
+  add_foreign_key "invitations", "users", column: "inviter_id"
   add_foreign_key "registrations", "conferences"
   add_foreign_key "registrations", "users"
   add_foreign_key "schedules", "conferences"

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class InvitationsControllerTest < ActionController::TestCase
+  setup do
+    @user = User.create!(
+      email: "inviter@example.com",
+      first_name: "Invite",
+      last_name: "Sender",
+      role: "Member"
+    )
+    @conference = conferences(:one)
+  end
+
+  test "should create an invitation for the signed-in user" do
+    session[:user_id] = @user.id
+
+    assert_difference("Invitation.count", 1) do
+      post :create, params: {
+        invitation: {
+          first_name: "Guest",
+          email: "guest@example.com"
+        }
+      }
+    end
+
+    invitation = Invitation.last
+    body = flash[:invitation_email_body]
+
+    assert_equal @user, invitation.inviter
+    assert_equal @conference, invitation.conference
+    assert_equal "guest@example.com", invitation.email
+    assert invitation.token_digest.present?
+    assert invitation.expires_at.present?
+    assert_nil invitation.used_at
+    assert_includes body, "Hi Guest,"
+    assert_includes body, "Invitation token:"
+    assert_includes body, "Use this invitation link to register:"
+    token = body[/invitation_token=([^\s]+)/, 1]
+    assert token.present?
+    assert_equal invitation, Invitation.find_by_token(token)
+    assert_redirected_to root_url
+  end
+
+  test "should reject invalid invitations" do
+    session[:user_id] = @user.id
+
+    assert_no_difference("Invitation.count") do
+      post :create, params: {
+        invitation: {
+          first_name: "",
+          email: "not-an-email"
+        }
+      }
+    end
+
+    assert_nil flash[:invitation_email_body]
+    assert_redirected_to root_url
+  end
+end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -36,7 +36,7 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, "FMUG Conferences"
     assert_includes response.body, "You are already registered for FMUG 1"
-    assert_includes response.body, "already-registered-invitation-modal"
+    assert_includes response.body, "known-user-invitation-modal"
     assert invitation.reload.used_at.present?
   end
 
@@ -68,7 +68,7 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "shows success message for a valid invitation token when invited email belongs to an existing unregistered user" do
-    User.create!(
+    invitation_user = User.create!(
       email: "guest@example.com",
       first_name: "Existing",
       last_name: "Guest",
@@ -84,10 +84,32 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     get root_path(invitation_token: invitation.raw_token)
 
     assert_response :success
-    assert_includes response.body, "Token validated and still valid"
-    assert_includes response.body, "you&#39;re already a user"
-    assert_includes response.body, "you&#39;re not registered for the upcoming FMUG"
-    assert_not_includes response.body, "you are already registered for FMUG #1"
+    assert_includes response.body, "FMUG Conferences"
+    assert_includes response.body, "Welcome back #{invitation_user.first_name}, you are not yet registered for the upcoming FMUG"
+    assert_includes response.body, "known-user-invitation-modal"
+    assert_not_includes response.body, "Token validated and still valid"
+    assert invitation.reload.used_at.present?
+  end
+
+  test "consumed token becomes invalid after unregistered known user visit" do
+    User.create!(
+      email: "guest@example.com",
+      first_name: "Existing",
+      last_name: "Guest",
+      role: "Member"
+    )
+    invitation = Invitation.create!(
+      inviter: @inviter,
+      conference: @conference,
+      first_name: "Guest",
+      email: "guest@example.com"
+    )
+
+    get root_path(invitation_token: invitation.raw_token)
+    get root_path(invitation_token: invitation.raw_token)
+
+    assert_response :success
+    assert_includes response.body, "Invalid invitation token"
   end
 
   test "shows success message for a valid invitation token when invited email is new" do

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -1,7 +1,55 @@
 require "test_helper"
 
 class PagesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @inviter = User.create!(
+      email: "inviter@example.com",
+      first_name: "Invite",
+      last_name: "Sender",
+      role: "Member"
+    )
+    @conference = conferences(:one)
+  end
+
+  test "shows success message for a valid invitation token" do
+    invitation = Invitation.create!(
+      inviter: @inviter,
+      conference: @conference,
+      first_name: "Guest",
+      email: "guest@example.com"
+    )
+
+    get root_path(invitation_token: invitation.raw_token)
+
+    assert_response :success
+    assert_includes response.body, "Token validated and still valid"
+    assert_not_includes response.body, "Invite attendee"
+    assert_not_includes response.body, "Register me for the conference"
+  end
+
+  test "shows invalid message for an unknown invitation token" do
+    get root_path(invitation_token: "not-a-real-token")
+
+    assert_response :success
+    assert_includes response.body, "Invalid invitation token"
+    assert_not_includes response.body, "Invite attendee"
+    assert_not_includes response.body, "Register me for the conference"
+  end
+
+  test "shows invalid message for an expired invitation token" do
+    invitation = Invitation.create!(
+      inviter: @inviter,
+      conference: @conference,
+      first_name: "Guest",
+      email: "guest@example.com"
+    )
+    invitation.update!(expires_at: 1.minute.ago)
+
+    get root_path(invitation_token: invitation.raw_token)
+
+    assert_response :success
+    assert_includes response.body, "Invalid invitation token"
+    assert_not_includes response.body, "Invite attendee"
+    assert_not_includes response.body, "Register me for the conference"
+  end
 end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -11,7 +11,39 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     @conference = conferences(:one)
   end
 
-  test "shows success message for a valid invitation token when invited email belongs to an existing user" do
+  test "shows success message for a valid invitation token when invited email belongs to an existing registered user" do
+    user = User.create!(
+      email: "guest@example.com",
+      first_name: "Existing",
+      last_name: "Guest",
+      role: "Member"
+    )
+    Registration.create!(
+      user: user,
+      conference: @conference,
+      attending_physically: true,
+      agenda_nothing_to_present: true
+    )
+    invitation = Invitation.create!(
+      inviter: @inviter,
+      conference: @conference,
+      first_name: "Guest",
+      email: "guest@example.com"
+    )
+
+    get root_path(invitation_token: invitation.raw_token)
+
+    assert_response :success
+    assert_includes response.body, "Token validated and still valid"
+    assert_includes response.body, "you&#39;re already a user"
+    assert_includes response.body, "you are already registered for FMUG #1"
+    assert_not_includes response.body, "welcome new user"
+    assert_not_includes response.body, "you&#39;re not registered for the upcoming FMUG"
+    assert_not_includes response.body, "Invite attendee"
+    assert_not_includes response.body, "Register me for the conference"
+  end
+
+  test "shows success message for a valid invitation token when invited email belongs to an existing unregistered user" do
     User.create!(
       email: "guest@example.com",
       first_name: "Existing",
@@ -30,9 +62,8 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, "Token validated and still valid"
     assert_includes response.body, "you&#39;re already a user"
-    assert_not_includes response.body, "welcome new user"
-    assert_not_includes response.body, "Invite attendee"
-    assert_not_includes response.body, "Register me for the conference"
+    assert_includes response.body, "you&#39;re not registered for the upcoming FMUG"
+    assert_not_includes response.body, "you are already registered for FMUG #1"
   end
 
   test "shows success message for a valid invitation token when invited email is new" do
@@ -49,6 +80,8 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Token validated and still valid"
     assert_includes response.body, "welcome new user"
     assert_not_includes response.body, "you&#39;re already a user"
+    assert_not_includes response.body, "you are already registered for FMUG #1"
+    assert_not_includes response.body, "you&#39;re not registered for the upcoming FMUG"
     assert_not_includes response.body, "Invite attendee"
     assert_not_includes response.body, "Register me for the conference"
   end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -123,13 +123,28 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     get root_path(invitation_token: invitation.raw_token)
 
     assert_response :success
-    assert_includes response.body, "Token validated and still valid"
-    assert_includes response.body, "welcome new user"
-    assert_not_includes response.body, "you&#39;re already a user"
-    assert_not_includes response.body, "you are already registered for FMUG #1"
-    assert_not_includes response.body, "you&#39;re not registered for the upcoming FMUG"
-    assert_not_includes response.body, "Invite attendee"
-    assert_not_includes response.body, "Register me for the conference"
+    assert_includes response.body, "FMUG Conferences"
+    assert_includes response.body, "new-user-invitation-modal"
+    assert_includes response.body, "Complete your FMUG profile"
+    assert_includes response.body, "value=\"guest@example.com\""
+    assert_not_includes response.body, "Invalid invitation token"
+    assert_nil invitation.reload.used_at
+  end
+
+  test "new user token remains valid after landing page visit" do
+    invitation = Invitation.create!(
+      inviter: @inviter,
+      conference: @conference,
+      first_name: "Guest",
+      email: "guest@example.com"
+    )
+
+    get root_path(invitation_token: invitation.raw_token)
+    get root_path(invitation_token: invitation.raw_token)
+
+    assert_response :success
+    assert_includes response.body, "new-user-invitation-modal"
+    assert_nil invitation.reload.used_at
   end
 
   test "shows invalid message for an unknown invitation token" do

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -34,13 +34,37 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     get root_path(invitation_token: invitation.raw_token)
 
     assert_response :success
-    assert_includes response.body, "Token validated and still valid"
-    assert_includes response.body, "you&#39;re already a user"
-    assert_includes response.body, "you are already registered for FMUG #1"
-    assert_not_includes response.body, "welcome new user"
-    assert_not_includes response.body, "you&#39;re not registered for the upcoming FMUG"
-    assert_not_includes response.body, "Invite attendee"
-    assert_not_includes response.body, "Register me for the conference"
+    assert_includes response.body, "FMUG Conferences"
+    assert_includes response.body, "You are already registered for FMUG 1"
+    assert_includes response.body, "already-registered-invitation-modal"
+    assert invitation.reload.used_at.present?
+  end
+
+  test "consumed token becomes invalid after registered user visit" do
+    user = User.create!(
+      email: "guest@example.com",
+      first_name: "Existing",
+      last_name: "Guest",
+      role: "Member"
+    )
+    Registration.create!(
+      user: user,
+      conference: @conference,
+      attending_physically: true,
+      agenda_nothing_to_present: true
+    )
+    invitation = Invitation.create!(
+      inviter: @inviter,
+      conference: @conference,
+      first_name: "Guest",
+      email: "guest@example.com"
+    )
+
+    get root_path(invitation_token: invitation.raw_token)
+    get root_path(invitation_token: invitation.raw_token)
+
+    assert_response :success
+    assert_includes response.body, "Invalid invitation token"
   end
 
   test "shows success message for a valid invitation token when invited email belongs to an existing unregistered user" do

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -11,7 +11,13 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     @conference = conferences(:one)
   end
 
-  test "shows success message for a valid invitation token" do
+  test "shows success message for a valid invitation token when invited email belongs to an existing user" do
+    User.create!(
+      email: "guest@example.com",
+      first_name: "Existing",
+      last_name: "Guest",
+      role: "Member"
+    )
     invitation = Invitation.create!(
       inviter: @inviter,
       conference: @conference,
@@ -23,6 +29,26 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, "Token validated and still valid"
+    assert_includes response.body, "you&#39;re already a user"
+    assert_not_includes response.body, "welcome new user"
+    assert_not_includes response.body, "Invite attendee"
+    assert_not_includes response.body, "Register me for the conference"
+  end
+
+  test "shows success message for a valid invitation token when invited email is new" do
+    invitation = Invitation.create!(
+      inviter: @inviter,
+      conference: @conference,
+      first_name: "Guest",
+      email: "guest@example.com"
+    )
+
+    get root_path(invitation_token: invitation.raw_token)
+
+    assert_response :success
+    assert_includes response.body, "Token validated and still valid"
+    assert_includes response.body, "welcome new user"
+    assert_not_includes response.body, "you&#39;re already a user"
     assert_not_includes response.body, "Invite attendee"
     assert_not_includes response.body, "Register me for the conference"
   end

--- a/test/models/invitation_test.rb
+++ b/test/models/invitation_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class InvitationTest < ActiveSupport::TestCase
+  setup do
+    @inviter = User.create!(
+      email: "inviter@example.com",
+      first_name: "Invite",
+      last_name: "Sender",
+      role: "Member"
+    )
+    @conference = conferences(:one)
+  end
+
+  test "creates a digest-backed token with a seven day expiry" do
+    freeze_time do
+      invitation = Invitation.create!(
+        inviter: @inviter,
+        conference: @conference,
+        first_name: " Guest ",
+        email: "GUEST@Example.com "
+      )
+
+      assert_equal "Guest", invitation.first_name
+      assert_equal "guest@example.com", invitation.email
+      assert invitation.raw_token.present?
+      assert_equal Invitation.digest(invitation.raw_token), invitation.token_digest
+      assert_equal invitation, Invitation.find_by_token(invitation.raw_token)
+      assert_in_delta 7.days.from_now.to_f, invitation.expires_at.to_f, 1.0
+      assert invitation.usable?
+    end
+  end
+
+  test "becomes unusable once expired or consumed" do
+    invitation = Invitation.create!(
+      inviter: @inviter,
+      conference: @conference,
+      first_name: "Guest",
+      email: "guest@example.com"
+    )
+
+    invitation.update!(expires_at: 1.minute.ago)
+    assert invitation.expired?
+    assert_not invitation.usable?
+
+    invitation.update!(expires_at: 7.days.from_now, used_at: nil)
+    invitation.mark_as_used!
+    assert_not invitation.usable?
+    assert invitation.used_at.present?
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  test "user is valid without a role" do
+    user = User.new(
+      email: "member@example.com",
+      first_name: "Member",
+      last_name: "User"
+    )
+
+    assert user.valid?
+  end
+end


### PR DESCRIPTION
Summary
- add invitations controller and model with secure token lifecycle plus email preview helpers and related routes/migration changes
- expand landing page logic and scripts to surface popup flows for known vs new invitees and preview invitation drafts
- cover invitations controller/pages controller interactions with new tests that validate token handling and UX flags

Testing
- Not run (not requested)