### PR TITLE
Add Login button and clarify magic link messaging

### DIFF
--- a/app/controllers/login_magic_links_controller.rb
+++ b/app/controllers/login_magic_links_controller.rb
@@ -1,0 +1,52 @@
+class LoginMagicLinksController < ApplicationController
+  before_action :redirect_if_logged_in, only: :create
+
+  def create
+    user = User.find_by(email: login_magic_link_params[:email].to_s.strip.downcase)
+
+    unless user
+      redirect_to root_path, alert: "No FMUG account was found for that email address."
+      return
+    end
+
+    login_magic_link = user.login_magic_links.create!
+
+    EmailDeliveryService.notify(
+      to: user.email,
+      subject: helpers.login_magic_link_email_subject,
+      body: helpers.login_magic_link_email_body(login_magic_link),
+      html_body: helpers.login_magic_link_email_html_body(login_magic_link),
+      from_name: "FMUG Chair",
+      from_email: "chair@fmug.eu",
+      delivery: :brevo
+    )
+
+    redirect_to root_path, notice: "A login magic link has been sent. It is valid for 15 minutes."
+  end
+
+  def show
+    login_magic_link = LoginMagicLink.find_by_token(params[:token])
+
+    unless login_magic_link&.usable?
+      render "magic_links/invalid", status: :unprocessable_entity
+      return
+    end
+
+    login_magic_link.mark_as_used!
+    session[:user_id] = login_magic_link.user.id
+
+    redirect_to root_path, notice: "Signed in successfully."
+  end
+
+  private
+
+  def login_magic_link_params
+    params.require(:login_magic_link).permit(:email)
+  end
+
+  def redirect_if_logged_in
+    return unless logged_in?
+
+    redirect_to root_path, alert: "You are already signed in."
+  end
+end

--- a/app/controllers/magic_links_controller.rb
+++ b/app/controllers/magic_links_controller.rb
@@ -1,0 +1,75 @@
+class MagicLinksController < ApplicationController
+  before_action :redirect_if_logged_in, only: :create
+
+  def create
+    invitation = Invitation.find_by_token(magic_link_params[:invitation_token])
+
+    unless invitation&.usable?
+      redirect_to root_path, alert: "This invitation is no longer valid."
+      return
+    end
+
+    if User.exists?(email: invitation.email)
+      redirect_to root_path(invitation_token: invitation.raw_token || magic_link_params[:invitation_token]), alert: "An account already exists for this invitation."
+      return
+    end
+
+    magic_link = invitation.magic_links.create!(magic_link_request_attributes)
+
+    EmailDeliveryService.notify(
+      to: invitation.email,
+      subject: helpers.magic_link_email_subject,
+      body: helpers.magic_link_email_body(magic_link),
+      html_body: helpers.magic_link_email_html_body(magic_link),
+      from_name: "FMUG Chair",
+      from_email: "chair@fmug.eu",
+      delivery: :brevo
+    )
+
+    redirect_to root_path, notice: "Your magic link has been sent. It is valid for 15 minutes."
+  rescue ActiveRecord::RecordInvalid
+    redirect_to root_path(invitation_token: magic_link_params[:invitation_token]), alert: "Please enter both your first name and last name."
+  end
+
+  def show
+    magic_link = MagicLink.find_by_token(params[:token])
+
+    unless magic_link&.usable?
+      render :invalid, status: :unprocessable_entity
+      return
+    end
+
+    user = nil
+
+    ActiveRecord::Base.transaction do
+      user = User.find_or_create_by!(email: magic_link.invitation.email) do |record|
+        record.first_name = magic_link.first_name
+        record.last_name = magic_link.last_name
+        record.role = "Member"
+      end
+
+      magic_link.mark_as_used!
+      magic_link.invitation.mark_as_used!
+    end
+
+    session[:user_id] = user.id
+
+    redirect_to root_path, notice: "Your account has been activated and you are now signed in."
+  end
+
+  private
+
+  def magic_link_params
+    params.require(:magic_link).permit(:invitation_token, :first_name, :last_name)
+  end
+
+  def magic_link_request_attributes
+    magic_link_params.slice(:first_name, :last_name)
+  end
+
+  def redirect_if_logged_in
+    return unless logged_in?
+
+    redirect_to root_path, alert: "You are already signed in."
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -146,4 +146,35 @@ module ApplicationHelper
       content_tag(:p, "FMUG Chair")
     ])
   end
+
+  def login_magic_link_email_subject
+    "Your FMUG login link"
+  end
+
+  def login_magic_link_email_body(login_magic_link)
+    [
+      "Hi #{login_magic_link.user.first_name},",
+      "",
+      "Use this link within 15 minutes to log in to the FMUG Community website:",
+      login_magic_link_url(login_magic_link.raw_token),
+      "",
+      "If you did not request this email, you can ignore it.",
+      "",
+      "Kind regards,",
+      "FMUG Chair"
+    ].join("\n")
+  end
+
+  def login_magic_link_email_html_body(login_magic_link)
+    link = login_magic_link_url(login_magic_link.raw_token)
+
+    safe_join([
+      content_tag(:p, "Hi #{login_magic_link.user.first_name},"),
+      content_tag(:p, "Use this link within 15 minutes to log in to the FMUG Community website:"),
+      content_tag(:p, link_to(link, link)),
+      content_tag(:p, "If you did not request this email, you can ignore it."),
+      content_tag(:p, "Kind regards,"),
+      content_tag(:p, "FMUG Chair")
+    ])
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -112,4 +112,38 @@ module ApplicationHelper
       content_tag(:p, inviter_name)
     ])
   end
+
+  def magic_link_email_subject
+    "Your FMUG magic link"
+  end
+
+  def magic_link_email_body(magic_link)
+    [
+      "Hi #{magic_link.first_name},",
+      "",
+      "Your FMUG magic link is ready.",
+      "",
+      "Use this link within 15 minutes to activate your account and sign in:",
+      magic_link_url(magic_link.raw_token),
+      "",
+      "After you click it, your invitation will be completed and you will be signed in.",
+      "",
+      "Kind regards,",
+      "FMUG Chair"
+    ].join("\n")
+  end
+
+  def magic_link_email_html_body(magic_link)
+    link = magic_link_url(magic_link.raw_token)
+
+    safe_join([
+      content_tag(:p, "Hi #{magic_link.first_name},"),
+      content_tag(:p, "Your FMUG magic link is ready."),
+      content_tag(:p, "Use this link within 15 minutes to activate your account and sign in:"),
+      content_tag(:p, link_to(link, link)),
+      content_tag(:p, "After you click it, your invitation will be completed and you will be signed in."),
+      content_tag(:p, "Kind regards,"),
+      content_tag(:p, "FMUG Chair")
+    ])
+  end
 end

--- a/app/models/login_magic_link.rb
+++ b/app/models/login_magic_link.rb
@@ -1,0 +1,51 @@
+class LoginMagicLink < ApplicationRecord
+  EXPIRATION_PERIOD = 15.minutes
+
+  belongs_to :user
+
+  attr_reader :raw_token
+
+  before_validation :assign_token, on: :create
+  before_validation :assign_expiration, on: :create
+
+  validates :token_digest, :expires_at, presence: true
+  validates :token_digest, uniqueness: true
+
+  scope :active, -> { where(used_at: nil).where("expires_at > ?", Time.current) }
+
+  def expired?
+    expires_at <= Time.current
+  end
+
+  def usable?
+    used_at.nil? && !expired?
+  end
+
+  def mark_as_used!
+    update!(used_at: Time.current)
+  end
+
+  def self.find_by_token(token)
+    find_by(token_digest: digest(token))
+  end
+
+  def self.digest(token)
+    Digest::SHA256.hexdigest(token.to_s)
+  end
+
+  private
+
+  def assign_token
+    return if token_digest.present?
+
+    loop do
+      @raw_token = SecureRandom.urlsafe_base64(32)
+      self.token_digest = self.class.digest(@raw_token)
+      break unless self.class.exists?(token_digest: token_digest)
+    end
+  end
+
+  def assign_expiration
+    self.expires_at ||= EXPIRATION_PERIOD.from_now
+  end
+end

--- a/app/models/magic_link.rb
+++ b/app/models/magic_link.rb
@@ -1,9 +1,7 @@
-class Invitation < ApplicationRecord
-  EXPIRATION_PERIOD = 7.days
+class MagicLink < ApplicationRecord
+  EXPIRATION_PERIOD = 15.minutes
 
-  belongs_to :conference
-  belongs_to :inviter, class_name: "User"
-  has_many :magic_links, dependent: :destroy
+  belongs_to :invitation
 
   attr_reader :raw_token
 
@@ -11,8 +9,7 @@ class Invitation < ApplicationRecord
   before_validation :assign_token, on: :create
   before_validation :assign_expiration, on: :create
 
-  validates :email, :first_name, :token_digest, :expires_at, presence: true
-  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :first_name, :last_name, :token_digest, :expires_at, presence: true
   validates :token_digest, uniqueness: true
 
   scope :active, -> { where(used_at: nil).where("expires_at > ?", Time.current) }
@@ -22,7 +19,7 @@ class Invitation < ApplicationRecord
   end
 
   def usable?
-    used_at.nil? && !expired?
+    invitation.usable? && used_at.nil? && !expired?
   end
 
   def mark_as_used!
@@ -41,7 +38,7 @@ class Invitation < ApplicationRecord
 
   def normalize_attributes
     self.first_name = first_name.to_s.strip
-    self.email = email.to_s.strip.downcase
+    self.last_name = last_name.to_s.strip
   end
 
   def assign_token

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   belongs_to :company, optional: true
   has_many :identities, dependent: :destroy
+  has_many :login_magic_links, dependent: :destroy
   has_many :registrations, dependent: :destroy
   has_many :sent_invitations, class_name: "Invitation", foreign_key: :inviter_id, dependent: :destroy
   has_many :conferences, through: :registrations

--- a/app/views/magic_links/invalid.html.erb
+++ b/app/views/magic_links/invalid.html.erb
@@ -1,5 +1,5 @@
-<section class="mx-auto max-w-3xl px-6 py-16">
-  <div class="rounded-3xl border border-stone-200 bg-white px-10 py-12 text-center shadow-sm">
+<section class="flex min-h-[70vh] w-full items-center justify-center px-6 py-16">
+  <div class="w-full max-w-3xl rounded-3xl border border-stone-200 bg-white px-10 py-12 text-center shadow-sm">
     <h1 class="text-4xl font-bold text-stone-900">Magic Link used is not valid</h1>
   </div>
 </section>

--- a/app/views/magic_links/invalid.html.erb
+++ b/app/views/magic_links/invalid.html.erb
@@ -1,0 +1,5 @@
+<section class="mx-auto max-w-3xl px-6 py-16">
+  <div class="rounded-3xl border border-stone-200 bg-white px-10 py-12 text-center shadow-sm">
+    <h1 class="text-4xl font-bold text-stone-900">Magic Link used is not valid</h1>
+  </div>
+</section>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -280,34 +280,27 @@ end %>
   <div id="new-user-invitation-modal" class="registration-modal" hidden>
     <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="new-user-invitation-title">
       <h2 id="new-user-invitation-title" class="registration-modal__title">Complete your FMUG profile</h2>
-      <p class="registration-modal__copy">Please provide your details to prepare your user account.</p>
+      <p class="registration-modal__copy">Please provide your name to prepare your member account.</p>
+      <p class="registration-modal__copy">To finish the registration, you will receive a magic link by email on the same address where the invitation was originally sent. The link is valid for 15 minutes.</p>
 
-      <div class="mt-5 text-left">
-        <label class="invite-modal__field" for="new-user-invitation-email">
-          Email address
-          <input
-            id="new-user-invitation-email"
-            class="invite-modal__input"
-            type="email"
-            value="<%= @invitation.email %>"
-            readonly
-          />
-        </label>
+      <%= form_with scope: :magic_link, url: magic_links_path, method: :post, local: true, id: "new-user-invitation-form", class: "mt-5 text-left" do |form| %>
+        <%= form.hidden_field :invitation_token, value: params[:invitation_token] %>
 
         <label class="invite-modal__field" for="new-user-invitation-first-name">
           First name
-          <input id="new-user-invitation-first-name" class="invite-modal__input" type="text" autocomplete="given-name" />
+          <%= form.text_field :first_name, id: "new-user-invitation-first-name", class: "invite-modal__input", autocomplete: "given-name", required: true, value: @invitation.first_name %>
         </label>
 
         <label class="invite-modal__field" for="new-user-invitation-last-name">
           Last name
-          <input id="new-user-invitation-last-name" class="invite-modal__input" type="text" autocomplete="family-name" />
+          <%= form.text_field :last_name, id: "new-user-invitation-last-name", class: "invite-modal__input", autocomplete: "family-name", required: true %>
         </label>
-      </div>
 
-      <div class="registration-modal__actions">
-        <button type="button" id="new-user-invitation-close" class="landing-auth__button">Close</button>
-      </div>
+        <div class="registration-modal__actions">
+          <button type="button" id="new-user-invitation-close" class="landing-auth__button">Close</button>
+          <button type="submit" id="send-magic-link" class="landing-auth__button">Send magic link</button>
+        </div>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -236,10 +236,13 @@ end %>
     <% if logged_in? %>
       <span class="landing-auth__meta">Signed in as <%= current_user.email %><%= " (Admin)" if current_user.admin? %></span>
       <%= button_to "Logout", logout_path, method: :delete, class: "landing-auth__button" %>
-    <% elsif google_oauth_configured? %>
-      <%= button_to "Login with Google", "/auth/google_oauth2", method: :post, class: "landing-auth__button" %>
     <% else %>
-      <span class="landing-auth__meta">Google login is not configured yet.</span>
+      <button type="button" id="login-magic-link-open" class="landing-auth__button">Login</button>
+      <% if google_oauth_configured? %>
+        <%= button_to "Login with Google", "/auth/google_oauth2", method: :post, class: "landing-auth__button" %>
+      <% else %>
+        <span class="landing-auth__meta">Google login is not configured yet.</span>
+      <% end %>
     <% end %>
   </div>
 
@@ -304,6 +307,27 @@ end %>
     </div>
   </div>
 <% end %>
+
+<div id="login-magic-link-modal" class="registration-modal" hidden>
+  <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="login-magic-link-title">
+    <h2 id="login-magic-link-title" class="registration-modal__title">Login</h2>
+    <p class="registration-modal__copy">Enter your registered email address and we will send you a magic link to log in to the FMUG Community website. The link is valid for 15 minutes.</p>
+
+    <%= form_with scope: :login_magic_link, url: login_magic_links_path, method: :post, local: true, id: "login-magic-link-form", class: "mt-5 text-left" do |form| %>
+      <label class="invite-modal__field" for="login-magic-link-email">
+        Email address
+        <%= form.email_field :email, id: "login-magic-link-email", class: "invite-modal__input", autocomplete: "email", required: true %>
+      </label>
+
+      <p id="login-magic-link-error" class="invite-modal__error" hidden>Please enter your email address before continuing.</p>
+
+      <div class="registration-modal__actions">
+        <button type="button" id="login-magic-link-close" class="landing-auth__button">Close</button>
+        <button type="submit" id="login-magic-link-submit" class="landing-auth__button">Send magic link</button>
+      </div>
+    <% end %>
+  </div>
+</div>
 
 <div id="self-registration-modal" class="registration-modal" hidden>
   <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="self-registration-title">
@@ -482,6 +506,12 @@ end %>
     const registerSection = document.getElementById("register-section");
     const registerSelfOption = document.getElementById("register-self-option");
     const inviteOtherOption = document.getElementById("invite-other-option");
+    const loginMagicLinkOpen = document.getElementById("login-magic-link-open");
+    const loginMagicLinkModal = document.getElementById("login-magic-link-modal");
+    const loginMagicLinkClose = document.getElementById("login-magic-link-close");
+    const loginMagicLinkForm = document.getElementById("login-magic-link-form");
+    const loginMagicLinkEmail = document.getElementById("login-magic-link-email");
+    const loginMagicLinkError = document.getElementById("login-magic-link-error");
     const registrationNextButton = document.getElementById("registration-next-button");
     const scheduleButton = document.getElementById("schedule-button");
     const scheduleSection = document.getElementById("schedule-section");
@@ -543,6 +573,27 @@ end %>
       }
 
       selfRegistrationModal.hidden = true;
+    };
+
+    const closeLoginMagicLinkModal = () => {
+      if (!loginMagicLinkModal) {
+        return;
+      }
+
+      loginMagicLinkModal.hidden = true;
+    };
+
+    const openLoginMagicLinkModal = () => {
+      if (!loginMagicLinkModal) {
+        return;
+      }
+
+      if (loginMagicLinkError) {
+        loginMagicLinkError.hidden = true;
+      }
+
+      loginMagicLinkModal.hidden = false;
+      loginMagicLinkEmail?.focus();
     };
 
     const openSelfRegistrationModal = () => {
@@ -707,6 +758,26 @@ end %>
         }
       });
     }
+
+    loginMagicLinkOpen?.addEventListener("click", openLoginMagicLinkModal);
+    loginMagicLinkClose?.addEventListener("click", closeLoginMagicLinkModal);
+    loginMagicLinkForm?.addEventListener("submit", (event) => {
+      const email = loginMagicLinkEmail?.value.trim();
+
+      if (email) {
+        if (loginMagicLinkError) {
+          loginMagicLinkError.hidden = true;
+        }
+
+        return;
+      }
+
+      event.preventDefault();
+
+      if (loginMagicLinkError) {
+        loginMagicLinkError.hidden = false;
+      }
+    });
 
     if (registrationNextButton && registerSelfOption) {
       registrationNextButton.addEventListener("click", () => {
@@ -939,6 +1010,12 @@ end %>
     newUserInvitationModal?.addEventListener("click", (event) => {
       if (event.target === newUserInvitationModal) {
         closeNewUserInvitationModal();
+      }
+    });
+
+    loginMagicLinkModal?.addEventListener("click", (event) => {
+      if (event.target === loginMagicLinkModal) {
+        closeLoginMagicLinkModal();
       }
     });
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   resources :schedules
   resources :conferences
   resources :invitations, only: [ :create ]
+  resources :magic_links, only: [ :create ]
   resource :registration, only: [ :create, :destroy ]
+  get "/magic-links/:token", to: "magic_links#show", as: :magic_link
   match "/auth/:provider/callback", to: "sessions#create", via: [ :get, :post ]
   match "/auth/failure", to: "sessions#failure", via: [ :get, :post ]
   delete "/logout", to: "sessions#destroy", as: :logout

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,10 @@ Rails.application.routes.draw do
   resources :conferences
   resources :invitations, only: [ :create ]
   resources :magic_links, only: [ :create ]
+  resources :login_magic_links, only: [ :create ]
   resource :registration, only: [ :create, :destroy ]
   get "/magic-links/:token", to: "magic_links#show", as: :magic_link
+  get "/login-magic-links/:token", to: "login_magic_links#show", as: :login_magic_link
   match "/auth/:provider/callback", to: "sessions#create", via: [ :get, :post ]
   match "/auth/failure", to: "sessions#failure", via: [ :get, :post ]
   delete "/logout", to: "sessions#destroy", as: :logout

--- a/db/migrate/20260313211000_create_magic_links.rb
+++ b/db/migrate/20260313211000_create_magic_links.rb
@@ -1,0 +1,16 @@
+class CreateMagicLinks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :magic_links do |t|
+      t.references :invitation, null: false, foreign_key: true
+      t.string :first_name, null: false
+      t.string :last_name, null: false
+      t.string :token_digest, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :used_at
+
+      t.timestamps
+    end
+
+    add_index :magic_links, :token_digest, unique: true
+  end
+end

--- a/db/migrate/20260313222500_create_login_magic_links.rb
+++ b/db/migrate/20260313222500_create_login_magic_links.rb
@@ -1,0 +1,14 @@
+class CreateLoginMagicLinks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :login_magic_links do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :token_digest, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :used_at
+
+      t.timestamps
+    end
+
+    add_index :login_magic_links, :token_digest, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_13_211000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_13_222500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -89,6 +89,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_13_211000) do
     t.index ["token_digest"], name: "index_invitations_on_token_digest", unique: true
   end
 
+  create_table "login_magic_links", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "token_digest", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "used_at"
+    t.bigint "user_id", null: false
+    t.index ["token_digest"], name: "index_login_magic_links_on_token_digest", unique: true
+    t.index ["user_id"], name: "index_login_magic_links_on_user_id"
+  end
+
   create_table "magic_links", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "expires_at", null: false
@@ -150,6 +161,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_13_211000) do
   add_foreign_key "identities", "users"
   add_foreign_key "invitations", "conferences"
   add_foreign_key "invitations", "users", column: "inviter_id"
+  add_foreign_key "login_magic_links", "users"
   add_foreign_key "magic_links", "invitations"
   add_foreign_key "registrations", "conferences"
   add_foreign_key "registrations", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_12_202732) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_13_211000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -89,6 +89,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_12_202732) do
     t.index ["token_digest"], name: "index_invitations_on_token_digest", unique: true
   end
 
+  create_table "magic_links", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "first_name", null: false
+    t.bigint "invitation_id", null: false
+    t.string "last_name", null: false
+    t.string "token_digest", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "used_at"
+    t.index ["invitation_id"], name: "index_magic_links_on_invitation_id"
+    t.index ["token_digest"], name: "index_magic_links_on_token_digest", unique: true
+  end
+
   create_table "registrations", force: :cascade do |t|
     t.boolean "agenda_nothing_to_present", default: false, null: false
     t.boolean "agenda_present", default: false, null: false
@@ -137,6 +150,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_12_202732) do
   add_foreign_key "identities", "users"
   add_foreign_key "invitations", "conferences"
   add_foreign_key "invitations", "users", column: "inviter_id"
+  add_foreign_key "magic_links", "invitations"
   add_foreign_key "registrations", "conferences"
   add_foreign_key "registrations", "users"
   add_foreign_key "schedules", "conferences"

--- a/test/controllers/login_magic_links_controller_test.rb
+++ b/test/controllers/login_magic_links_controller_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class LoginMagicLinksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(
+      email: "member@example.com",
+      first_name: "Member",
+      last_name: "Example",
+      role: "Member"
+    )
+  end
+
+  test "creates and emails a login magic link for an existing user" do
+    delivery_payload = nil
+
+    with_replaced_singleton_method(EmailDeliveryService, :notify, ->(**kwargs) {
+      delivery_payload = kwargs
+      { "messageId" => "<brevo@example.com>" }
+    }) do
+      assert_difference("LoginMagicLink.count", 1) do
+        post login_magic_links_path, params: { login_magic_link: { email: "member@example.com" } }
+      end
+    end
+
+    assert_equal "member@example.com", delivery_payload[:to]
+    assert_equal "Your FMUG login link", delivery_payload[:subject]
+    assert_equal :brevo, delivery_payload[:delivery]
+    assert_includes delivery_payload[:body], "log in to the FMUG Community website"
+    assert_redirected_to root_url
+  end
+
+  test "signs in the user when the login magic link is opened" do
+    login_magic_link = @user.login_magic_links.create!
+
+    get login_magic_link_path(login_magic_link.raw_token)
+
+    assert_redirected_to root_url
+    follow_redirect!
+    assert_includes response.body, "Signed in as member@example.com"
+    assert_equal @user.id, session[:user_id]
+    assert login_magic_link.reload.used_at.present?
+  end
+
+  test "renders invalid page for expired login magic links" do
+    login_magic_link = @user.login_magic_links.create!
+    login_magic_link.update!(expires_at: 1.minute.ago)
+
+    get login_magic_link_path(login_magic_link.raw_token)
+
+    assert_response :unprocessable_entity
+    assert_includes response.body, "Magic Link used is not valid"
+  end
+
+  private
+
+  def with_replaced_singleton_method(object, method_name, implementation)
+    singleton_class = object.singleton_class
+    original_method = singleton_class.instance_method(method_name) if singleton_class.method_defined?(method_name)
+
+    singleton_class.define_method(method_name, implementation)
+    yield
+  ensure
+    if original_method
+      singleton_class.define_method(method_name, original_method)
+    else
+      singleton_class.remove_method(method_name)
+    end
+  end
+end

--- a/test/controllers/magic_links_controller_test.rb
+++ b/test/controllers/magic_links_controller_test.rb
@@ -1,0 +1,97 @@
+require "test_helper"
+
+class MagicLinksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @inviter = User.create!(
+      email: "inviter@example.com",
+      first_name: "Invite",
+      last_name: "Sender",
+      role: "Member"
+    )
+    @conference = conferences(:one)
+    @invitation = Invitation.create!(
+      inviter: @inviter,
+      conference: @conference,
+      first_name: "Guest",
+      email: "guest@example.com"
+    )
+  end
+
+  test "creates and emails a magic link for a new invited user" do
+    delivery_payload = nil
+
+    with_replaced_singleton_method(EmailDeliveryService, :notify, ->(**kwargs) {
+      delivery_payload = kwargs
+      { "messageId" => "<brevo@example.com>" }
+    }) do
+      assert_difference("MagicLink.count", 1) do
+        post magic_links_path, params: {
+          magic_link: {
+            invitation_token: @invitation.raw_token,
+            first_name: "Guest",
+            last_name: "Member"
+          }
+        }
+      end
+    end
+
+    magic_link = MagicLink.last
+
+    assert_equal @invitation, magic_link.invitation
+    assert_equal "guest@example.com", delivery_payload[:to]
+    assert_equal "Your FMUG magic link", delivery_payload[:subject]
+    assert_equal :brevo, delivery_payload[:delivery]
+    assert_includes delivery_payload[:body], "Use this link within 15 minutes"
+    token = delivery_payload[:body][/magic-links\/([^\s]+)/, 1]
+    assert token.present?
+    assert_includes delivery_payload[:body], magic_link_path(token)
+    assert_redirected_to root_url
+    follow_redirect!
+    assert_includes response.body, "Your magic link has been sent. It is valid for 15 minutes."
+  end
+
+  test "activates the user and signs them in when the magic link is opened" do
+    magic_link = @invitation.magic_links.create!(first_name: "Guest", last_name: "Member")
+
+    get magic_link_path(magic_link.raw_token)
+
+    assert_redirected_to root_url
+    follow_redirect!
+
+    user = User.find_by(email: "guest@example.com")
+    assert_not_nil user
+    assert_equal "Guest", user.first_name
+    assert_equal "Member", user.last_name
+    assert_includes response.body, "Signed in as guest@example.com"
+    assert_equal user.id, session[:user_id]
+    assert @invitation.reload.used_at.present?
+    assert magic_link.reload.used_at.present?
+  end
+
+  test "rejects expired magic links" do
+    magic_link = @invitation.magic_links.create!(first_name: "Guest", last_name: "Member")
+    magic_link.update!(expires_at: 1.minute.ago)
+
+    get magic_link_path(magic_link.raw_token)
+
+    assert_response :unprocessable_entity
+    assert_includes response.body, "Magic Link used is not valid"
+    assert_nil User.find_by(email: "guest@example.com")
+  end
+
+  private
+
+  def with_replaced_singleton_method(object, method_name, implementation)
+    singleton_class = object.singleton_class
+    original_method = singleton_class.instance_method(method_name) if singleton_class.method_defined?(method_name)
+
+    singleton_class.define_method(method_name, implementation)
+    yield
+  ensure
+    if original_method
+      singleton_class.define_method(method_name, original_method)
+    else
+      singleton_class.remove_method(method_name)
+    end
+  end
+end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -126,7 +126,8 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "FMUG Conferences"
     assert_includes response.body, "new-user-invitation-modal"
     assert_includes response.body, "Complete your FMUG profile"
-    assert_includes response.body, "value=\"guest@example.com\""
+    assert_includes response.body, "value=\"#{invitation.raw_token}\""
+    assert_not_includes response.body, "new-user-invitation-email"
     assert_not_includes response.body, "Invalid invitation token"
     assert_nil invitation.reload.used_at
   end


### PR DESCRIPTION
## Summary
- add a standalone “Login” button beside “Login with Google” that prompts for the registered email and sends the standard magic link for FMUG Community login
- ensure magic links (expired or invalid) now show a centered “Magic Link used is not valid” message
- align messaging to make it clear the link logs into the FMUG Community site with a 15-minute validity window and keeps the chair@fmug.eu sender information

## Testing
- Not run (not requested)