### PR TITLE
Add members list with admin controls and delete confirmations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,4 +23,10 @@ class ApplicationController < ActionController::Base
 
     redirect_to root_path, alert: "Please sign in first."
   end
+
+  def require_admin
+    return if logged_in? && current_user.admin?
+
+    redirect_to root_path, alert: "You are not authorized to perform that action."
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,21 @@
+class UsersController < ApplicationController
+  before_action :require_login
+  before_action :require_admin, only: :admin
+
+  def index
+    @users = User.order(:first_name, :last_name)
+  end
+
+  def admin
+    user = User.find(params[:id])
+
+    if user == current_user
+      redirect_to users_path, alert: "You cannot remove your own admin rights."
+      return
+    end
+
+    user.update!(admin: ActiveModel::Type::Boolean.new.cast(params[:admin]))
+
+    redirect_to users_path, notice: "#{user.first_name} #{user.last_name} admin access updated."
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,30 @@ class UsersController < ApplicationController
     @users = User.order(:first_name, :last_name)
   end
 
+  def destroy
+    user = User.find(params[:id])
+    deleting_self = user == current_user
+
+    unless deleting_self || current_user.admin?
+      redirect_to users_path, alert: "You can only delete your own account."
+      return
+    end
+
+    if deleting_self && current_user.admin?
+      redirect_to users_path, alert: "Admins cannot delete their own account."
+      return
+    end
+
+    user.destroy!
+    reset_session if deleting_self
+
+    if deleting_self
+      redirect_to root_path, notice: "Your account has been deleted."
+    else
+      redirect_to users_path, notice: "#{user.first_name} #{user.last_name} has been deleted."
+    end
+  end
+
   def admin
     user = User.find(params[:id])
 

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -7,9 +7,18 @@ end %>
 <style>
   .landing-auth {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .landing-auth__group {
+    display: flex;
     align-items: center;
     gap: 12px;
+    flex-wrap: wrap;
   }
 
   .landing-auth__button {
@@ -233,17 +242,25 @@ end %>
 <% else %>
 <div class="flex w-full flex-col space-y-8">
   <div class="landing-auth">
-    <% if logged_in? %>
-      <span class="landing-auth__meta">Signed in as <%= current_user.email %><%= " (Admin)" if current_user.admin? %></span>
-      <%= button_to "Logout", logout_path, method: :delete, class: "landing-auth__button" %>
-    <% else %>
-      <button type="button" id="login-magic-link-open" class="landing-auth__button">Login</button>
-      <% if google_oauth_configured? %>
-        <%= button_to "Login with Google", "/auth/google_oauth2", method: :post, class: "landing-auth__button" %>
-      <% else %>
-        <span class="landing-auth__meta">Google login is not configured yet.</span>
+    <div class="landing-auth__group">
+      <% if logged_in? %>
+        <%= link_to "Members", users_path, class: "landing-auth__button" %>
       <% end %>
-    <% end %>
+    </div>
+
+    <div class="landing-auth__group">
+      <% if logged_in? %>
+        <span class="landing-auth__meta">Signed in as <%= current_user.email %><%= " (Admin)" if current_user.admin? %></span>
+        <%= button_to "Logout", logout_path, method: :delete, class: "landing-auth__button" %>
+      <% else %>
+        <button type="button" id="login-magic-link-open" class="landing-auth__button">Login</button>
+        <% if google_oauth_configured? %>
+          <%= button_to "Login with Google", "/auth/google_oauth2", method: :post, class: "landing-auth__button" %>
+        <% else %>
+          <span class="landing-auth__meta">Google login is not configured yet.</span>
+        <% end %>
+      <% end %>
+    </div>
   </div>
 
   <div class="flex w-full justify-center">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -7,24 +7,34 @@
   </div>
 
   <div class="w-full max-w-2xl overflow-hidden rounded-3xl border border-stone-200 bg-white shadow-sm">
-    <ul class="divide-y divide-stone-200">
+    <ul class="bg-stone-50 px-6 py-8">
       <% @users.each do |user| %>
-        <li class="px-6 py-5 text-center text-2xl text-stone-800">
-          <span>
-            <%= [user.first_name, user.last_name].join(" ") %><%= " (Admin)" if user.admin? %>
-          </span>
-          <% if current_user.admin? %>
-            <span class="ml-3 text-xl text-stone-500"><%= user.email %></span>
-            <span class="ml-4 inline-flex align-middle">
-              <% if user == current_user %>
-                <button type="button" class="rounded-full border border-stone-300 bg-stone-100 px-4 py-2 text-base font-medium text-stone-500" disabled>
-                  Admin On
-                </button>
-              <% else %>
-                <%= button_to(user.admin? ? "Admin On" : "Admin Off", admin_user_path(user), method: :patch, params: { admin: !user.admin? }, class: "rounded-full border border-stone-300 bg-white px-4 py-2 text-base font-medium text-stone-700 transition hover:bg-stone-100") %>
+        <% avatar_seed = ERB::Util.url_encode("#{user.first_name}-#{user.last_name}-#{user.id}") %>
+        <li class="mb-8 last:mb-0">
+          <div class="flex w-full flex-col items-center gap-5 rounded-3xl bg-white px-6 pt-16 pb-14 text-center text-stone-800 shadow-sm ring-1 ring-stone-200">
+            <%= image_tag "https://robohash.org/#{avatar_seed}.png?set=set4&size=180x180", alt: "#{user.first_name} #{user.last_name} avatar", class: "h-36 w-36 rounded-full border border-stone-200 object-cover shadow-sm" %>
+
+            <div class="text-2xl">
+              <span>
+                <%= [user.first_name, user.last_name].join(" ") %><%= " (Admin)" if user.admin? %>
+              </span>
+              <% if current_user.admin? %>
+                <span class="ml-3 text-xl text-stone-500"><%= user.email %></span>
               <% end %>
-            </span>
-          <% end %>
+            </div>
+
+            <% if current_user.admin? %>
+              <div>
+                <% if user == current_user %>
+                  <button type="button" class="rounded-full border border-stone-300 bg-stone-100 px-4 py-2 text-base font-medium text-stone-500" disabled>
+                    Admin On
+                  </button>
+                <% else %>
+                  <%= button_to(user.admin? ? "Admin On" : "Admin Off", admin_user_path(user), method: :patch, params: { admin: !user.admin? }, class: "rounded-full border border-stone-300 bg-white px-4 py-2 text-base font-medium text-stone-700 transition hover:bg-stone-100") %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
         </li>
       <% end %>
     </ul>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -24,14 +24,22 @@
             </div>
 
             <% if current_user.admin? %>
-              <div>
+              <div class="flex flex-wrap items-center justify-center gap-3">
                 <% if user == current_user %>
                   <button type="button" class="rounded-full border border-stone-300 bg-stone-100 px-4 py-2 text-base font-medium text-stone-500" disabled>
                     Admin On
                   </button>
+                  <button type="button" class="rounded-full border border-red-200 bg-red-50 px-4 py-2 text-base font-medium text-red-300" disabled>
+                    Delete
+                  </button>
                 <% else %>
                   <%= button_to(user.admin? ? "Admin On" : "Admin Off", admin_user_path(user), method: :patch, params: { admin: !user.admin? }, class: "rounded-full border border-stone-300 bg-white px-4 py-2 text-base font-medium text-stone-700 transition hover:bg-stone-100") %>
+                  <%= button_to "Delete", user_path(user), method: :delete, form: { onsubmit: "return confirm('Are you sure you want to delete this account?');" }, class: "rounded-full border border-red-300 bg-white px-4 py-2 text-base font-medium text-red-700 transition hover:bg-red-50" %>
                 <% end %>
+              </div>
+            <% elsif user == current_user %>
+              <div>
+                <%= button_to "Delete My Account", user_path(user), method: :delete, form: { onsubmit: "return confirm('Are you sure you want to delete your account?');" }, class: "rounded-full border border-red-300 bg-white px-4 py-2 text-base font-medium text-red-700 transition hover:bg-red-50" %>
               </div>
             <% end %>
           </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,32 @@
+<% content_for :title, "FMUG Members" %>
+
+<div class="mx-auto flex w-full max-w-4xl flex-col items-center gap-8">
+  <div class="flex w-full max-w-2xl items-center justify-between gap-4">
+    <h1 class="text-4xl font-semibold text-stone-900">Members</h1>
+    <%= link_to "Back", root_path, class: "landing-auth__button" %>
+  </div>
+
+  <div class="w-full max-w-2xl overflow-hidden rounded-3xl border border-stone-200 bg-white shadow-sm">
+    <ul class="divide-y divide-stone-200">
+      <% @users.each do |user| %>
+        <li class="px-6 py-5 text-center text-2xl text-stone-800">
+          <span>
+            <%= [user.first_name, user.last_name].join(" ") %><%= " (Admin)" if user.admin? %>
+          </span>
+          <% if current_user.admin? %>
+            <span class="ml-3 text-xl text-stone-500"><%= user.email %></span>
+            <span class="ml-4 inline-flex align-middle">
+              <% if user == current_user %>
+                <button type="button" class="rounded-full border border-stone-300 bg-stone-100 px-4 py-2 text-base font-medium text-stone-500" disabled>
+                  Admin On
+                </button>
+              <% else %>
+                <%= button_to(user.admin? ? "Admin On" : "Admin Off", admin_user_path(user), method: :patch, params: { admin: !user.admin? }, class: "rounded-full border border-stone-300 bg-white px-4 py-2 text-base font-medium text-stone-700 transition hover:bg-stone-100") %>
+              <% end %>
+            </span>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   resources :schedules
   resources :conferences
-  resources :users, only: [ :index ] do
+  resources :users, only: [ :index, :destroy ] do
     patch :admin, on: :member
   end
   resources :invitations, only: [ :create ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   resources :schedules
   resources :conferences
+  resources :users, only: [ :index ] do
+    patch :admin, on: :member
+  end
   resources :invitations, only: [ :create ]
   resources :magic_links, only: [ :create ]
   resources :login_magic_links, only: [ :create ]

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,122 @@
+require "test_helper"
+
+class UsersControllerTest < ActionController::TestCase
+  setup do
+    @member = User.create!(
+      email: "member@example.com",
+      first_name: "Ada",
+      last_name: "Lovelace",
+      role: "Member"
+    )
+    @other_member = User.create!(
+      email: "other@example.com",
+      first_name: "Grace",
+      last_name: "Hopper",
+      role: "Member"
+    )
+  end
+
+  test "redirects guests away from the members list" do
+    get :index
+
+    assert_redirected_to root_path
+    assert_equal "Please sign in first.", flash[:alert]
+  end
+
+  test "shows the members list when signed in" do
+    @other_member.update!(admin: true)
+
+    session[:user_id] = @member.id
+    get :index
+
+    assert_response :success
+    assert_includes response.body, "Members"
+    assert_includes response.body, "Ada Lovelace"
+    assert_includes response.body, "Grace Hopper (Admin)"
+    assert_not_includes response.body, "member@example.com"
+    assert_not_includes response.body, "other@example.com"
+  end
+
+  test "shows member email addresses to admins" do
+    @member.update!(admin: true)
+    @other_member.update!(admin: true)
+
+    session[:user_id] = @member.id
+    get :index
+
+    assert_response :success
+    assert_includes response.body, "Ada Lovelace (Admin)"
+    assert_includes response.body, "member@example.com"
+    assert_includes response.body, "Grace Hopper (Admin)"
+    assert_includes response.body, "other@example.com"
+    assert_includes response.body, "Admin On"
+  end
+
+  test "admins can grant admin rights to another user" do
+    @member.update!(admin: true)
+
+    session[:user_id] = @member.id
+    patch :admin, params: { id: @other_member.id, admin: true }
+
+    assert_redirected_to users_path
+    assert_equal "Grace Hopper admin access updated.", flash[:notice]
+    assert @other_member.reload.admin?
+  end
+
+  test "admins can remove admin rights from another user" do
+    @member.update!(admin: true)
+    @other_member.update!(admin: true)
+
+    session[:user_id] = @member.id
+    patch :admin, params: { id: @other_member.id, admin: false }
+
+    assert_redirected_to users_path
+    assert_equal "Grace Hopper admin access updated.", flash[:notice]
+    assert_not @other_member.reload.admin?
+  end
+
+  test "admins cannot remove their own admin rights" do
+    @member.update!(admin: true)
+
+    session[:user_id] = @member.id
+    patch :admin, params: { id: @member.id, admin: false }
+
+    assert_redirected_to users_path
+    assert_equal "You cannot remove your own admin rights.", flash[:alert]
+    assert @member.reload.admin?
+  end
+
+  test "non-admins cannot change admin rights" do
+    session[:user_id] = @member.id
+    patch :admin, params: { id: @other_member.id, admin: true }
+
+    assert_redirected_to root_path
+    assert_equal "You are not authorized to perform that action.", flash[:alert]
+    assert_not @other_member.reload.admin?
+  end
+end
+
+class LandingMembersNavigationTest < ActionController::TestCase
+  tests PagesController
+
+  test "shows the members button on the landing page only when signed in" do
+    get :landing
+
+    assert_response :success
+    assert_not_includes response.body, ">Members<"
+
+    member = User.create!(
+      email: "member@example.com",
+      first_name: "Ada",
+      last_name: "Lovelace",
+      role: "Member"
+    )
+    session[:user_id] = member.id
+
+    get :landing
+
+    assert_response :success
+    assert_includes response.body, ">Members<"
+    assert_includes response.body, users_path
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -50,6 +50,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_includes response.body, "Grace Hopper (Admin)"
     assert_includes response.body, "other@example.com"
     assert_includes response.body, "Admin On"
+    assert_includes response.body, "Delete"
   end
 
   test "admins can grant admin rights to another user" do
@@ -93,6 +94,54 @@ class UsersControllerTest < ActionController::TestCase
     assert_redirected_to root_path
     assert_equal "You are not authorized to perform that action.", flash[:alert]
     assert_not @other_member.reload.admin?
+  end
+
+  test "members can delete their own account" do
+    session[:user_id] = @member.id
+
+    assert_difference("User.count", -1) do
+      delete :destroy, params: { id: @member.id }
+    end
+
+    assert_redirected_to root_path
+    assert_equal "Your account has been deleted.", flash[:notice]
+    assert_nil session[:user_id]
+  end
+
+  test "members cannot delete another account" do
+    session[:user_id] = @member.id
+
+    assert_no_difference("User.count") do
+      delete :destroy, params: { id: @other_member.id }
+    end
+
+    assert_redirected_to users_path
+    assert_equal "You can only delete your own account.", flash[:alert]
+  end
+
+  test "admins cannot delete their own account" do
+    @member.update!(admin: true)
+    session[:user_id] = @member.id
+
+    assert_no_difference("User.count") do
+      delete :destroy, params: { id: @member.id }
+    end
+
+    assert_redirected_to users_path
+    assert_equal "Admins cannot delete their own account.", flash[:alert]
+    assert @member.reload.admin?
+  end
+
+  test "admins can delete another account" do
+    @member.update!(admin: true)
+    session[:user_id] = @member.id
+
+    assert_difference("User.count", -1) do
+      delete :destroy, params: { id: @other_member.id }
+    end
+
+    assert_redirected_to users_path
+    assert_equal "Grace Hopper has been deleted.", flash[:notice]
   end
 end
 


### PR DESCRIPTION
Summary
- add a members listing, landing page navigation, and updated layout so signed-in users can reach the management UI
- implement user admin toggles plus guarded deletion logic, routes, and controller tests covering self-delete and admin constraints
- wire delete buttons to confirmation prompts so members see the “are you sure” warning before removing their account

Testing
- Not run (not requested)