### PR TITLE
Add conference admin link to the landing page

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -1,4 +1,5 @@
 class ConferencesController < ApplicationController
+  before_action :require_admin
   before_action :set_conference, only: %i[ show edit update destroy ]
 
   # GET /conferences or /conferences.json

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -245,6 +245,9 @@ end %>
     <div class="landing-auth__group">
       <% if logged_in? %>
         <%= link_to "Members", users_path, class: "landing-auth__button" %>
+        <% if current_user.admin? %>
+          <%= link_to "Conference Admin", conferences_path, class: "landing-auth__button" %>
+        <% end %>
       <% end %>
     </div>
 

--- a/test/controllers/conferences_controller_test.rb
+++ b/test/controllers/conferences_controller_test.rb
@@ -1,24 +1,59 @@
 require "test_helper"
 require "stringio"
 
-class ConferencesControllerTest < ActionDispatch::IntegrationTest
+class ConferencesControllerTest < ActionController::TestCase
   setup do
     @conference = conferences(:one)
+    @admin = User.create!(
+      email: "admin@example.com",
+      first_name: "Admin",
+      last_name: "User",
+      role: "Member",
+      admin: true
+    )
+    @member = User.create!(
+      email: "member@example.com",
+      first_name: "Member",
+      last_name: "User",
+      role: "Member"
+    )
+  end
+
+  test "redirects guests away from conference management" do
+    get :index
+
+    assert_redirected_to root_path
+    assert_equal "You are not authorized to perform that action.", flash[:alert]
+  end
+
+  test "redirects non-admins away from conference management" do
+    session[:user_id] = @member.id
+
+    get :index
+
+    assert_redirected_to root_path
+    assert_equal "You are not authorized to perform that action.", flash[:alert]
   end
 
   test "should get index" do
-    get conferences_url
+    session[:user_id] = @admin.id
+
+    get :index
     assert_response :success
   end
 
   test "should get new" do
-    get new_conference_url
+    session[:user_id] = @admin.id
+
+    get :new
     assert_response :success
   end
 
   test "should create conference" do
+    session[:user_id] = @admin.id
+
     assert_difference("Conference.count") do
-      post conferences_url, params: {
+      post :create, params: {
         conference: {
           edition: 2,
           start_date: Date.current,
@@ -34,17 +69,24 @@ class ConferencesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should show conference" do
-    get conference_url(@conference)
+    session[:user_id] = @admin.id
+
+    get :show, params: { id: @conference.id }
     assert_response :success
   end
 
   test "should get edit" do
-    get edit_conference_url(@conference)
+    session[:user_id] = @admin.id
+
+    get :edit, params: { id: @conference.id }
     assert_response :success
   end
 
   test "should update conference" do
-    patch conference_url(@conference), params: {
+    session[:user_id] = @admin.id
+
+    patch :update, params: {
+      id: @conference.id,
       conference: {
         edition: @conference.edition,
         start_date: @conference.start_date,
@@ -58,21 +100,25 @@ class ConferencesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should destroy conference" do
+    session[:user_id] = @admin.id
+
     assert_difference("Conference.count", -1) do
-      delete conference_url(@conference)
+      delete :destroy, params: { id: @conference.id }
     end
 
     assert_redirected_to conferences_url
   end
 
   test "should remove conference image" do
+    session[:user_id] = @admin.id
     @conference.image.attach(
       io: StringIO.new("fake-image"),
       filename: "conference.png",
       content_type: "image/png"
     )
 
-    patch conference_url(@conference), params: {
+    patch :update, params: {
+      id: @conference.id,
       conference: {
         edition: @conference.edition,
         start_date: @conference.start_date,

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -168,4 +168,33 @@ class LandingMembersNavigationTest < ActionController::TestCase
     assert_includes response.body, ">Members<"
     assert_includes response.body, users_path
   end
+
+  test "shows the conference admin button on the landing page only to admins" do
+    member = User.create!(
+      email: "member@example.com",
+      first_name: "Ada",
+      last_name: "Lovelace",
+      role: "Member"
+    )
+    admin = User.create!(
+      email: "admin@example.com",
+      first_name: "Grace",
+      last_name: "Hopper",
+      role: "Member",
+      admin: true
+    )
+
+    session[:user_id] = member.id
+    get :landing
+
+    assert_response :success
+    assert_not_includes response.body, ">Conference Admin<"
+
+    session[:user_id] = admin.id
+    get :landing
+
+    assert_response :success
+    assert_includes response.body, ">Conference Admin<"
+    assert_includes response.body, conferences_path
+  end
 end


### PR DESCRIPTION
**Summary**
- Add a `Conference Admin` button next to `Members` on the landing page
- Show the button only to signed-in admins
- Restrict conference management routes to admins so the new entry point matches access control
- Update controller tests for landing page navigation and conference authorization

**Testing**
- `bin/rails test test/controllers/conferences_controller_test.rb`
- `bin/rails test test/controllers/users_controller_test.rb`