### PR TITLE
Add admin landing page links for conference and agenda management

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,4 +1,5 @@
 class SchedulesController < ApplicationController
+  before_action :require_admin, except: :agenda
   before_action :set_schedule, only: %i[ show edit update destroy ]
 
   # GET /schedules or /schedules.json

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -247,6 +247,7 @@ end %>
         <%= link_to "Members", users_path, class: "landing-auth__button" %>
         <% if current_user.admin? %>
           <%= link_to "Conference Admin", conferences_path, class: "landing-auth__button" %>
+          <%= link_to "Agenda Admin", schedules_path, class: "landing-auth__button" %>
         <% end %>
       <% end %>
     </div>

--- a/test/controllers/schedules_controller_test.rb
+++ b/test/controllers/schedules_controller_test.rb
@@ -1,24 +1,65 @@
 require "test_helper"
 
-class SchedulesControllerTest < ActionDispatch::IntegrationTest
+class SchedulesControllerTest < ActionController::TestCase
   setup do
     @schedule = schedules(:one)
     @current_conference = conferences(:one)
+    @admin = User.create!(
+      email: "admin@example.com",
+      first_name: "Admin",
+      last_name: "User",
+      role: "Member",
+      admin: true
+    )
+    @member = User.create!(
+      email: "member@example.com",
+      first_name: "Member",
+      last_name: "User",
+      role: "Member"
+    )
+  end
+
+  test "redirects guests away from agenda management" do
+    get :index
+
+    assert_redirected_to root_path
+    assert_equal "You are not authorized to perform that action.", flash[:alert]
+  end
+
+  test "redirects non-admins away from agenda management" do
+    session[:user_id] = @member.id
+
+    get :index
+
+    assert_redirected_to root_path
+    assert_equal "You are not authorized to perform that action.", flash[:alert]
+  end
+
+  test "allows public access to the published agenda" do
+    get :agenda
+
+    assert_response :success
   end
 
   test "should get index" do
-    get schedules_url
+    session[:user_id] = @admin.id
+
+    get :index
     assert_response :success
   end
 
   test "should get new" do
-    get new_schedule_url
+    session[:user_id] = @admin.id
+
+    get :new
     assert_response :success
   end
 
   test "should create schedule" do
+    session[:user_id] = @admin.id
+
     assert_difference("Schedule.count") do
-      post schedules_url, params: {
+      post :create, params: {
         schedule: {
           conference_id: @current_conference.id,
           day: 1,
@@ -33,17 +74,24 @@ class SchedulesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should show schedule" do
-    get schedule_url(@schedule)
+    session[:user_id] = @admin.id
+
+    get :show, params: { id: @schedule.id }
     assert_response :success
   end
 
   test "should get edit" do
-    get edit_schedule_url(@schedule)
+    session[:user_id] = @admin.id
+
+    get :edit, params: { id: @schedule.id }
     assert_response :success
   end
 
   test "should update schedule" do
-    patch schedule_url(@schedule), params: {
+    session[:user_id] = @admin.id
+
+    patch :update, params: {
+      id: @schedule.id,
       schedule: {
         conference_id: @current_conference.id,
         day: @schedule.day,
@@ -59,8 +107,10 @@ class SchedulesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should destroy schedule" do
+    session[:user_id] = @admin.id
+
     assert_difference("Schedule.count", -1) do
-      delete schedule_url(@schedule)
+      delete :destroy, params: { id: @schedule.id }
     end
 
     assert_redirected_to schedules_url

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -197,4 +197,33 @@ class LandingMembersNavigationTest < ActionController::TestCase
     assert_includes response.body, ">Conference Admin<"
     assert_includes response.body, conferences_path
   end
+
+  test "shows the agenda admin button on the landing page only to admins" do
+    member = User.create!(
+      email: "member@example.com",
+      first_name: "Ada",
+      last_name: "Lovelace",
+      role: "Member"
+    )
+    admin = User.create!(
+      email: "admin@example.com",
+      first_name: "Grace",
+      last_name: "Hopper",
+      role: "Member",
+      admin: true
+    )
+
+    session[:user_id] = member.id
+    get :landing
+
+    assert_response :success
+    assert_not_includes response.body, ">Agenda Admin<"
+
+    session[:user_id] = admin.id
+    get :landing
+
+    assert_response :success
+    assert_includes response.body, ">Agenda Admin<"
+    assert_includes response.body, schedules_path
+  end
 end


### PR DESCRIPTION
## Summary
- add admin-only `Conference Admin` and `Agenda Admin` buttons to the landing page navigation
- route the new buttons to the existing conference and schedule admin pages
- restrict conference and schedule admin controllers to admins while keeping the public agenda page accessible
- update controller tests to cover admin visibility and access control

## Testing
- `bin/rails test test/controllers/conferences_controller_test.rb`
- `bin/rails test test/controllers/schedules_controller_test.rb`
- `bin/rails test test/controllers/users_controller_test.rb`