### PR TITLE
Fix registration crash and harden admin and invitation flows

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -15,7 +15,7 @@ class RegistrationsController < ApplicationController
       return
     end
 
-    registration = current_user.registrations.create!(
+    registration = current_user.registrations.build(
       conference: @conference,
       attending_physically: attendance_mode == "physical",
       agenda_present: registration_params[:agenda_present],
@@ -27,6 +27,11 @@ class RegistrationsController < ApplicationController
       dietary_requirements_text: registration_params[:dietary_requirements_text],
       chair_note: registration_params[:chair_note]
     )
+
+    unless registration.save
+      redirect_to root_path, alert: registration.errors.full_messages.to_sentence
+      return
+    end
 
     email_attributes = registration_email_attributes(registration)
 

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -66,6 +66,43 @@ class RegistrationsControllerTest < ActionController::TestCase
     assert_redirected_to root_url
   end
 
+  test "should reject registration without an agenda selection instead of crashing" do
+    session[:user_id] = @user.id
+
+    assert_no_difference("Registration.count") do
+      post :create, params: {
+        registration: {
+          attendance_mode: "physical",
+          agenda_present: "0",
+          agenda_question: "0",
+          agenda_something_else: "0",
+          agenda_nothing_to_present: "0"
+        }
+      }
+    end
+
+    assert_redirected_to root_url
+    assert_equal "Select at least one agenda option", flash[:alert]
+  end
+
+  test "should reject registration with missing dietary details instead of crashing" do
+    session[:user_id] = @user.id
+
+    assert_no_difference("Registration.count") do
+      post :create, params: {
+        registration: {
+          attendance_mode: "physical",
+          agenda_present: "1",
+          has_dietary_requirements: "1",
+          dietary_requirements_text: "Please specify"
+        }
+      }
+    end
+
+    assert_redirected_to root_url
+    assert_equal "Dietary requirements text must be provided when dietary requirements are selected", flash[:alert]
+  end
+
   test "should remove an existing registration" do
     session[:user_id] = @user.id
     registration = Registration.create!(


### PR DESCRIPTION
## Summary
- add admin-only landing page links for conference and agenda management
- restrict conference and schedule admin pages to admins
- set session expiry to 8 hours
- consume existing-user invitations only after email ownership is proven via login magic link
- handle invalid registration submissions gracefully instead of raising server errors

## Testing
- `bin/rails test test/controllers/conferences_controller_test.rb`
- `bin/rails test test/controllers/schedules_controller_test.rb`
- `bin/rails test test/controllers/users_controller_test.rb`
- `bin/rails test test/controllers/pages_controller_test.rb`
- `bin/rails test test/controllers/login_magic_links_controller_test.rb`
- `bin/rails test test/controllers/registrations_controller_test.rb`