### PR TITLE
Add markdown-backed about content rendering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "jbuilder"
 gem "omniauth"
 gem "omniauth-rails_csrf_protection"
 gem "omniauth-google-oauth2"
+gem "redcarpet"
 
 gem "rspec"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,7 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redcarpet (3.6.1)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -453,6 +454,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.1)
+  redcarpet
   rspec
   rubocop-rails-omakase
   selenium-webdriver

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,2 +1,15 @@
 module PagesHelper
+  def render_markdown_content(path)
+    markdown = Redcarpet::Markdown.new(
+      Redcarpet::Render::HTML.new(filter_html: true, hard_wrap: true),
+      autolink: true,
+      fenced_code_blocks: true,
+      tables: true
+    )
+
+    html = markdown.render(File.read(Rails.root.join("content", path)))
+    sanitize(html, tags: %w[p br a em strong code pre ul ol li blockquote h1 h2 h3 h4 h5 h6], attributes: %w[href title])
+  rescue Errno::ENOENT
+    content_tag(:p, "Content file not found: #{path}")
+  end
 end

--- a/app/views/pages/_about.html.erb
+++ b/app/views/pages/_about.html.erb
@@ -1,23 +1,5 @@
-<div class="flex flex-col items-center">
-    <h1 class="text-3xl font-bold mb-4">About Section</h1>
-    <p class="text-lg">This is the about page content which is rendered.</p>
-
-    <div class="flex flex-col gap-4">
-      <div class="flex items-center gap-4">
-        <sl-avatar style="--size: 6rem;"
-          image="https://images.unsplash.com/photo-1529778873920-4da4926a72c2?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80"
-          label="Avatar of a gray tabby kitten looking down">
-        </sl-avatar>
-        <span class="text-xl font-medium">Chair</span>
-      </div>
-
-      <div class="flex items-center gap-4">
-        <sl-avatar style="--size: 6rem;"
-          image="https://images.unsplash.com/photo-1591871937573-74dbba515c4c?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80"
-          label="Avatar of a white and grey kitten on grey textile"
-          loading="lazy">
-        </sl-avatar>
-        <span class="text-xl font-medium">Vice-Chair</span>
-      </div>
-    </div>
+<section class="landing-copy">
+  <div>
+    <%= render_markdown_content("about.md") %>
   </div>
+</section>

--- a/app/views/pages/_about.html.erb
+++ b/app/views/pages/_about.html.erb
@@ -2,4 +2,23 @@
   <div>
     <%= render_markdown_content("about.md") %>
   </div>
+
+  <div class="mt-10 flex flex-col items-center gap-4">
+    <div class="grid w-full max-w-sm grid-cols-[6rem_1fr] items-center justify-center gap-4">
+      <sl-avatar style="--size: 6rem;"
+        image="https://images.unsplash.com/photo-1529778873920-4da4926a72c2?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80"
+        label="Avatar of a gray tabby kitten looking down">
+      </sl-avatar>
+      <span class="text-left text-xl font-medium text-stone-800">Chair</span>
+    </div>
+
+    <div class="grid w-full max-w-sm grid-cols-[6rem_1fr] items-center justify-center gap-4">
+      <sl-avatar style="--size: 6rem;"
+        image="https://images.unsplash.com/photo-1591871937573-74dbba515c4c?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80"
+        label="Avatar of a white and grey kitten on grey textile"
+        loading="lazy">
+      </sl-avatar>
+      <span class="text-left text-xl font-medium text-stone-800">Vice-Chair</span>
+    </div>
+  </div>
 </section>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -45,6 +45,60 @@ end %>
     font-size: 1.5rem;
   }
 
+  .landing-copy {
+    width: 100%;
+    max-width: 960px;
+    margin: 0 auto;
+    color: #292524;
+    text-align: center;
+  }
+
+  .landing-copy h1,
+  .landing-copy h2,
+  .landing-copy h3,
+  .landing-copy h4,
+  .landing-copy h5,
+  .landing-copy h6 {
+    margin: 0 0 12px;
+    font-weight: 700;
+    line-height: 1.05;
+    color: #1c1917;
+  }
+
+  .landing-copy h1 {
+    font-size: 3.4rem;
+  }
+
+  .landing-copy h2 {
+    font-size: 2.8rem;
+  }
+
+  .landing-copy p,
+  .landing-copy li,
+  .landing-copy blockquote {
+    font-size: 1.8rem;
+    line-height: 1.7;
+  }
+
+  .landing-copy p,
+  .landing-copy ul,
+  .landing-copy ol,
+  .landing-copy blockquote,
+  .landing-copy pre {
+    margin: 0 0 16px;
+  }
+
+  .landing-copy ul,
+  .landing-copy ol {
+    padding-left: 24px;
+    text-align: left;
+  }
+
+  .landing-copy a {
+    color: #0f766e;
+    text-decoration: underline;
+  }
+
   .registration-modal[hidden] {
     display: none;
   }

--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,1 @@
+This is a rendered about section.


### PR DESCRIPTION
## Summary
- add support for repo-managed markdown content using `redcarpet`
- introduce a top-level `content/` directory with an `about.md` file
- render the About section from markdown instead of hard-coded HTML
- restore and realign the Chair and Vice-Chair avatars under the About content
- improve the About section layout so it flows naturally with the landing page
- tighten invitation consumption and registration error handling to avoid premature invite use and server crashes
- add an 8-hour session timeout for signed-in users
- add admin-only landing page links for conference and agenda management, and protect those admin routes server-side

## Testing
- `bin/rails test test/controllers/pages_controller_test.rb`
- `bin/rails test test/controllers/login_magic_links_controller_test.rb`
- `bin/rails test test/controllers/registrations_controller_test.rb`
- `bin/rails test test/controllers/conferences_controller_test.rb`
- `bin/rails test test/controllers/schedules_controller_test.rb`
- `bin/rails test test/controllers/users_controller_test.rb`
- `bin/rails test test/controllers/magic_links_controller_test.rb`
- `bin/rails test test/controllers/login_magic_links_controller_test.rb`
- `bundle install`