### PR TITLE
Add markdown-backed landing page content sections

### DIFF
--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,5 +1,5 @@
 module PagesHelper
-  def render_markdown_content(path)
+  def render_markdown_content(path, fallback: nil)
     markdown = Redcarpet::Markdown.new(
       Redcarpet::Render::HTML.new(filter_html: true, hard_wrap: true),
       autolink: true,
@@ -10,6 +10,12 @@ module PagesHelper
     html = markdown.render(File.read(Rails.root.join("content", path)))
     sanitize(html, tags: %w[p br a em strong code pre ul ol li blockquote h1 h2 h3 h4 h5 h6], attributes: %w[href title])
   rescue Errno::ENOENT
-    content_tag(:p, "Content file not found: #{path}")
+    fallback
+  end
+
+  def render_conference_markdown(conference)
+    return unless conference.present?
+
+    render_markdown_content("conference/#{conference.edition}.md")
   end
 end

--- a/app/views/pages/_current.html.erb
+++ b/app/views/pages/_current.html.erb
@@ -12,7 +12,12 @@
         <%= conference.end_date.strftime("%b %-d, %Y") %><br>
         <strong>Location:</strong> <%= conference.location %><br>
       </p>
-      <p class="text-lg">Here you can add more (rendered) information about the upcoming conference.</p>
+      <% conference_markdown = render_conference_markdown(conference) %>
+      <% if conference_markdown.present? %>
+        <div class="landing-copy mt-4">
+          <%= conference_markdown %>
+        </div>
+      <% end %>
       <div class="flex justify-center space-x-4 mt-6">
         <sl-button pill id="register-button" type="button">Register</sl-button>
         <sl-button pill id="schedule-button" type="button" <%= "disabled" unless schedules_present %>>Agenda</sl-button>

--- a/content/conference/34.md
+++ b/content/conference/34.md
@@ -1,0 +1,1 @@
+This is rendered conference information for conference 34.


### PR DESCRIPTION
## Summary
- add repository-managed markdown rendering using `redcarpet`
- load About content from `content/about.md` and style it to match the landing page flow
- add conference-specific markdown support from `content/conference/<edition>.md`
- restore and align the chair and vice-chair avatars beneath the About section
- tighten landing page behavior around admin navigation, invitation consumption, and registration validation handling
- configure sessions to expire after 8 hours

## Testing
- `bin/rails test test/controllers/conferences_controller_test.rb`
- `bin/rails test test/controllers/schedules_controller_test.rb`
- `bin/rails test test/controllers/users_controller_test.rb`
- `bin/rails test test/controllers/login_magic_links_controller_test.rb`
- `bin/rails test test/controllers/magic_links_controller_test.rb`
- `bin/rails test test/controllers/registrations_controller_test.rb`
- `bin/rails test test/controllers/pages_controller_test.rb`