### PR TITLE
Add markdown-driven landing page content and admin navigation controls

### DIFF
--- a/app/views/pages/_current.html.erb
+++ b/app/views/pages/_current.html.erb
@@ -1,6 +1,7 @@
 <% conference = @current_conference %>
 <% schedules_present = defined?(@schedules) && @schedules.present? %>
 <% registration_name = logged_in? ? [current_user.first_name, current_user.last_name].compact.join(" ").presence : nil %>
+<% more_info_markdown = render_markdown_content("more-info.md") %>
 <% if conference %>
   <div class="mb-20 flex flex-col items-center">
       <h1 class="text-2xl font-bold mb-4">Upcoming Conference <%= conference.edition %></h1>
@@ -21,8 +22,14 @@
       <div class="flex justify-center space-x-4 mt-6">
         <sl-button pill id="register-button" type="button">Register</sl-button>
         <sl-button pill id="schedule-button" type="button" <%= "disabled" unless schedules_present %>>Agenda</sl-button>
-        <sl-button pill disabled>More information</sl-button>
+        <sl-button pill id="more-info-button" type="button" <%= "disabled" unless more_info_markdown.present? %>>More information</sl-button>
       </div>
+
+      <% if more_info_markdown.present? %>
+        <div id="more-info-section" class="landing-copy mt-8" style="display: none;">
+          <%= more_info_markdown %>
+        </div>
+      <% end %>
 
       <div id="register-section" class="hidden w-full max-w-xl rounded-2xl border border-stone-200 bg-white px-6 py-5 text-center shadow-sm" style="margin-top: 24px;">
         <p class="text-lg font-semibold uppercase tracking-[0.18em] text-stone-500">Registration</p>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -591,6 +591,8 @@ end %>
     const registrationNextButton = document.getElementById("registration-next-button");
     const scheduleButton = document.getElementById("schedule-button");
     const scheduleSection = document.getElementById("schedule-section");
+    const moreInfoButton = document.getElementById("more-info-button");
+    const moreInfoSection = document.getElementById("more-info-section");
     const selfRegistrationModal = document.getElementById("self-registration-modal");
     const selfRegistrationCancel = document.getElementById("self-registration-cancel");
     const selfRegistrationRemoveCancel = document.getElementById("self-registration-remove-cancel");
@@ -831,6 +833,21 @@ end %>
         } else {
           scheduleSection.style.display = "none";
           scheduleButton.classList.remove("is-active");
+        }
+      });
+    }
+
+    if (moreInfoButton && moreInfoSection && !moreInfoButton.hasAttribute("disabled")) {
+      moreInfoButton.addEventListener("click", () => {
+        const isHidden = moreInfoSection.style.display === "none";
+
+        if (isHidden) {
+          moreInfoSection.style.display = "block";
+          moreInfoButton.classList.add("is-active");
+          moreInfoSection.scrollIntoView({ behavior: "smooth" });
+        } else {
+          moreInfoSection.style.display = "none";
+          moreInfoButton.classList.remove("is-active");
         }
       });
     }

--- a/content/more-info.md
+++ b/content/more-info.md
@@ -1,0 +1,1 @@
+This is rendered additional information for the landing page.


### PR DESCRIPTION
## Summary
- add admin-only `Conference Admin` and `Agenda Admin` actions to the landing page
- restrict conference and schedule management routes to admins
- add markdown-backed content rendering from `content/` using `redcarpet`
- render markdown for the About section, conference-specific content, and landing-page more information
- update invitation handling so existing-user invites are consumed only after login proves email ownership
- handle invalid registration submissions without raising server errors
- configure sessions to expire after 8 hours

## Testing
- `bin/rails test test/controllers/conferences_controller_test.rb`
- `bin/rails test test/controllers/schedules_controller_test.rb`
- `bin/rails test test/controllers/users_controller_test.rb`
- `bin/rails test test/controllers/login_magic_links_controller_test.rb`
- `bin/rails test test/controllers/magic_links_controller_test.rb`
- `bin/rails test test/controllers/registrations_controller_test.rb`
- `bin/rails test test/controllers/pages_controller_test.rb`