### PR TITLE
Add landing page admin links, markdown content sections, and footer privacy page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -21,6 +21,9 @@ class PagesController < ApplicationController
     @schedules = nil
   end
 
+  def privacy
+  end
+
   private
 
   def find_valid_invitation(token)

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -294,94 +294,98 @@ end %>
     </div>
   </div>
 <% else %>
-<div class="flex w-full flex-col space-y-8">
-  <div class="landing-auth">
-    <div class="landing-auth__group">
-      <% if logged_in? %>
-        <%= link_to "Members", users_path, class: "landing-auth__button" %>
-        <% if current_user.admin? %>
-          <%= link_to "Conference Admin", conferences_path, class: "landing-auth__button" %>
-          <%= link_to "Agenda Admin", schedules_path, class: "landing-auth__button" %>
-        <% end %>
-      <% end %>
-    </div>
+  <div class="w-full">
+    <div class="flex w-full flex-col space-y-8">
+      <div class="landing-auth">
+        <div class="landing-auth__group">
+          <% if logged_in? %>
+            <%= link_to "Members", users_path, class: "landing-auth__button" %>
+            <% if current_user.admin? %>
+              <%= link_to "Conference Admin", conferences_path, class: "landing-auth__button" %>
+              <%= link_to "Agenda Admin", schedules_path, class: "landing-auth__button" %>
+            <% end %>
+          <% end %>
+        </div>
 
-    <div class="landing-auth__group">
-      <% if logged_in? %>
-        <span class="landing-auth__meta">Signed in as <%= current_user.email %><%= " (Admin)" if current_user.admin? %></span>
-        <%= button_to "Logout", logout_path, method: :delete, class: "landing-auth__button" %>
-      <% else %>
-        <button type="button" id="login-magic-link-open" class="landing-auth__button">Login</button>
-        <% if google_oauth_configured? %>
-          <%= button_to "Login with Google", "/auth/google_oauth2", method: :post, class: "landing-auth__button" %>
-        <% else %>
-          <span class="landing-auth__meta">Google login is not configured yet.</span>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
+        <div class="landing-auth__group">
+          <% if logged_in? %>
+            <span class="landing-auth__meta">Signed in as <%= current_user.email %><%= " (Admin)" if current_user.admin? %></span>
+            <%= button_to "Logout", logout_path, method: :delete, class: "landing-auth__button" %>
+          <% else %>
+            <button type="button" id="login-magic-link-open" class="landing-auth__button">Login</button>
+            <% if google_oauth_configured? %>
+              <%= button_to "Login with Google", "/auth/google_oauth2", method: :post, class: "landing-auth__button" %>
+            <% else %>
+              <span class="landing-auth__meta">Google login is not configured yet.</span>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
 
-  <div class="flex w-full justify-center">
-    <%= image_tag "fmug-400dpiLogo.jpeg", alt: "FMUG Logo", class: "mx-auto block h-auto max-h-[440px] w-auto max-w-full object-contain" %>
-  </div>
+      <div class="flex w-full justify-center">
+        <%= image_tag "fmug-400dpiLogo.jpeg", alt: "FMUG Logo", class: "mx-auto block h-auto max-h-[440px] w-auto max-w-full object-contain" %>
+      </div>
 
-  <%= render 'pages/about' %>
+      <%= render 'pages/about' %>
 
-  <%= render 'pages/current' %>
+      <%= render 'pages/current' %>
 
-  <div id="schedule-section" class="mt-10" style="display: none;">
-    <%= render template: "schedules/agenda" %>
-  </div>
+      <div id="schedule-section" class="mt-10" style="display: none;">
+        <%= render template: "schedules/agenda" %>
+      </div>
 
-  <div class="h-12 w-full"></div>
+      <div class="h-12 w-full"></div>
 
-  <div class="flex flex-row justify-center gap-8">
-
-    <%= render 'pages/upcoming' %>
-
-  </div>
-</div>
-
-<% if @show_known_user_invitation_popup %>
-  <div id="known-user-invitation-modal" class="registration-modal" hidden>
-    <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="known-user-invitation-title">
-      <h2 id="known-user-invitation-title" class="registration-modal__title">Registration status</h2>
-      <div class="registration-modal__draft"><%= @known_user_invitation_popup_message %></div>
-      <div class="registration-modal__actions">
-        <button type="button" id="known-user-invitation-close" class="landing-auth__button">Close</button>
+      <div class="flex flex-row justify-center gap-8">
+        <%= render 'pages/upcoming' %>
       </div>
     </div>
-  </div>
-<% end %>
 
-<% if @show_new_user_invitation_popup %>
-  <div id="new-user-invitation-modal" class="registration-modal" hidden>
-    <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="new-user-invitation-title">
-      <h2 id="new-user-invitation-title" class="registration-modal__title">Complete your FMUG profile</h2>
-      <p class="registration-modal__copy">Please provide your name to prepare your member account.</p>
-      <p class="registration-modal__copy">To finish the registration, you will receive a magic link by email on the same address where the invitation was originally sent. The link is valid for 15 minutes.</p>
-
-      <%= form_with scope: :magic_link, url: magic_links_path, method: :post, local: true, id: "new-user-invitation-form", class: "mt-5 text-left" do |form| %>
-        <%= form.hidden_field :invitation_token, value: params[:invitation_token] %>
-
-        <label class="invite-modal__field" for="new-user-invitation-first-name">
-          First name
-          <%= form.text_field :first_name, id: "new-user-invitation-first-name", class: "invite-modal__input", autocomplete: "given-name", required: true, value: @invitation.first_name %>
-        </label>
-
-        <label class="invite-modal__field" for="new-user-invitation-last-name">
-          Last name
-          <%= form.text_field :last_name, id: "new-user-invitation-last-name", class: "invite-modal__input", autocomplete: "family-name", required: true %>
-        </label>
-
-        <div class="registration-modal__actions">
-          <button type="button" id="new-user-invitation-close" class="landing-auth__button">Close</button>
-          <button type="submit" id="send-magic-link" class="landing-auth__button">Send magic link</button>
+    <footer class="mt-16 w-full pb-8 text-center text-lg text-stone-500">
+      <p>&copy; <%= Date.current.year %> Patrick Koers · <%= link_to "Privacy", privacy_path, class: "underline decoration-stone-400 underline-offset-4 hover:text-stone-700" %> · This is an AI and Humans collaboration</p>
+    </footer>
+  
+    <% if @show_known_user_invitation_popup %>
+      <div id="known-user-invitation-modal" class="registration-modal" hidden>
+        <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="known-user-invitation-title">
+          <h2 id="known-user-invitation-title" class="registration-modal__title">Registration status</h2>
+          <div class="registration-modal__draft"><%= @known_user_invitation_popup_message %></div>
+          <div class="registration-modal__actions">
+            <button type="button" id="known-user-invitation-close" class="landing-auth__button">Close</button>
+          </div>
         </div>
-      <% end %>
-    </div>
-  </div>
-<% end %>
+      </div>
+    <% end %>
+
+    <% if @show_new_user_invitation_popup %>
+      <div id="new-user-invitation-modal" class="registration-modal" hidden>
+        <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="new-user-invitation-title">
+          <h2 id="new-user-invitation-title" class="registration-modal__title">Complete your FMUG profile</h2>
+          <p class="registration-modal__copy">Please provide your name to prepare your member account.</p>
+          <p class="registration-modal__copy">To finish the registration, you will receive a magic link by email on the same address where the invitation was originally sent. The link is valid for 15 minutes.</p>
+
+          <%= form_with scope: :magic_link, url: magic_links_path, method: :post, local: true, id: "new-user-invitation-form", class: "mt-5 text-left" do |form| %>
+            <%= form.hidden_field :invitation_token, value: params[:invitation_token] %>
+
+            <label class="invite-modal__field" for="new-user-invitation-first-name">
+              First name
+              <%= form.text_field :first_name, id: "new-user-invitation-first-name", class: "invite-modal__input", autocomplete: "given-name", required: true, value: @invitation.first_name %>
+            </label>
+
+            <label class="invite-modal__field" for="new-user-invitation-last-name">
+              Last name
+              <%= form.text_field :last_name, id: "new-user-invitation-last-name", class: "invite-modal__input", autocomplete: "family-name", required: true %>
+            </label>
+
+            <div class="registration-modal__actions">
+              <button type="button" id="new-user-invitation-close" class="landing-auth__button">Close</button>
+              <button type="submit" id="send-magic-link" class="landing-auth__button">Send magic link</button>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  
 
 <div id="login-magic-link-modal" class="registration-modal" hidden>
   <div class="registration-modal__panel" role="dialog" aria-modal="true" aria-labelledby="login-magic-link-title">
@@ -1125,4 +1129,5 @@ end %>
     });
   });
 </script>
+</div>
 <% end %>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,0 +1,7 @@
+<% content_for :title, "Privacy" %>
+
+<div class="mx-auto w-full max-w-4xl px-6 py-10">
+  <div class="landing-copy">
+    <%= render_markdown_content("privacy.md") %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,5 +27,6 @@ Rails.application.routes.draw do
   # root "posts#index"
   root "pages#landing"
   get "about", to: "pages#about"
+  get "privacy", to: "pages#privacy"
   get "agenda", to: "schedules#agenda"
 end

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -1,0 +1,1 @@
+This is a placeholder privacy statement.

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -175,4 +175,20 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, "Invite attendee"
     assert_not_includes response.body, "Register me for the conference"
   end
+
+  test "shows the footer privacy link on the landing page" do
+    get root_path
+
+    assert_response :success
+    assert_includes response.body, "Patrick Koers"
+    assert_includes response.body, privacy_path
+    assert_includes response.body, "Privacy"
+  end
+
+  test "renders the privacy page from markdown content" do
+    get privacy_path
+
+    assert_response :success
+    assert_includes response.body, "This is a placeholder privacy statement."
+  end
 end


### PR DESCRIPTION
## Summary
- add admin-only landing page links for conference and agenda management
- enforce admin access for conference and schedule admin screens
- set session cookies to expire after 8 hours
- add markdown-backed content rendering from `content/` for About, conference details, more info, and privacy
- update the landing page to support inline more-info content and add a footer with privacy and collaboration text
- fix invitation consumption to happen after login link verification and handle invalid registration submissions without crashing

## Testing
- `bin/rails test test/controllers/conferences_controller_test.rb`
- `bin/rails test test/controllers/schedules_controller_test.rb`
- `bin/rails test test/controllers/users_controller_test.rb`
- `bin/rails test test/controllers/login_magic_links_controller_test.rb`
- `bin/rails test test/controllers/magic_links_controller_test.rb`
- `bin/rails test test/controllers/registrations_controller_test.rb`
- `bin/rails test test/controllers/pages_controller_test.rb`