### PR TITLE
Add draft privacy statement and improve privacy page styling

### DIFF
--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,7 +1,210 @@
 <% content_for :title, "Privacy" %>
 
-<div class="mx-auto w-full max-w-4xl px-6 py-10">
-  <div class="landing-copy">
-    <%= render_markdown_content("privacy.md") %>
+<style>
+  .privacy-page {
+    width: 100%;
+    background:
+      radial-gradient(circle at top left, rgba(191, 219, 254, 0.28), transparent 30%),
+      linear-gradient(180deg, #f8fafc 0%, #eef2f7 100%);
+    color: #1f2937;
+  }
+
+  .privacy-shell {
+    width: min(100%, 980px);
+    margin: 0 auto;
+    padding: 32px 20px 72px;
+  }
+
+  .privacy-hero {
+    margin-bottom: 24px;
+  }
+
+  .privacy-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 14px;
+    font-size: 1.3rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #475569;
+  }
+
+  .privacy-badge {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #cbd5e1;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.82);
+    padding: 6px 12px;
+    font-size: 1.2rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: #0f172a;
+  }
+
+  .privacy-hero h1 {
+    margin: 0;
+    font-size: clamp(3rem, 5vw, 4.6rem);
+    line-height: 1.08;
+    letter-spacing: -0.03em;
+    color: #0f172a;
+  }
+
+  .privacy-intro {
+    max-width: 720px;
+    margin-top: 14px;
+    font-size: 1.8rem;
+    line-height: 1.65;
+    color: #475569;
+  }
+
+  .privacy-meta {
+    margin-top: 16px;
+    font-size: 1.4rem;
+    line-height: 1.6;
+    color: #64748b;
+  }
+
+  .privacy-article {
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    border-radius: 24px;
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow:
+      0 24px 60px rgba(15, 23, 42, 0.08),
+      inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    padding: clamp(24px, 4vw, 48px);
+    backdrop-filter: blur(10px);
+  }
+
+  .privacy-article h1,
+  .privacy-article h2,
+  .privacy-article h3,
+  .privacy-article h4,
+  .privacy-article h5,
+  .privacy-article h6 {
+    margin: 0;
+    color: #0f172a;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+  }
+
+  .privacy-article h1 {
+    margin-bottom: 18px;
+    padding-bottom: 18px;
+    border-bottom: 1px solid #e2e8f0;
+    font-size: clamp(3.2rem, 4vw, 4.2rem);
+    line-height: 1.12;
+  }
+
+  .privacy-article h2 {
+    margin-top: 42px;
+    margin-bottom: 16px;
+    padding-top: 10px;
+    border-top: 1px solid #e2e8f0;
+    font-size: 2.5rem;
+    line-height: 1.2;
+  }
+
+  .privacy-article h3 {
+    margin-top: 28px;
+    margin-bottom: 12px;
+    font-size: 2rem;
+    line-height: 1.3;
+  }
+
+  .privacy-article p,
+  .privacy-article li,
+  .privacy-article blockquote {
+    font-size: 1.7rem;
+    line-height: 1.75;
+    color: #334155;
+  }
+
+  .privacy-article p,
+  .privacy-article ul,
+  .privacy-article ol,
+  .privacy-article blockquote,
+  .privacy-article pre {
+    margin: 0 0 18px;
+  }
+
+  .privacy-article ul,
+  .privacy-article ol {
+    padding-left: 24px;
+  }
+
+  .privacy-article li + li {
+    margin-top: 8px;
+  }
+
+  .privacy-article a {
+    color: #0969da;
+    text-decoration: none;
+    font-weight: 600;
+  }
+
+  .privacy-article a:hover {
+    text-decoration: underline;
+  }
+
+  .privacy-article strong {
+    color: #0f172a;
+    font-weight: 700;
+  }
+
+  .privacy-article code {
+    border: 1px solid #dbe3ee;
+    border-radius: 8px;
+    background: #f8fafc;
+    padding: 0.18em 0.42em;
+    font-size: 0.9em;
+    color: #0f172a;
+  }
+
+  .privacy-article blockquote {
+    border-left: 4px solid #bfdbfe;
+    margin-left: 0;
+    padding: 8px 0 8px 18px;
+    color: #475569;
+  }
+
+  @media (max-width: 640px) {
+    .privacy-shell {
+      padding: 24px 14px 48px;
+    }
+
+    .privacy-article {
+      border-radius: 18px;
+      padding: 22px 18px 28px;
+    }
+
+    .privacy-article p,
+    .privacy-article li,
+    .privacy-article blockquote {
+      font-size: 1.6rem;
+      line-height: 1.7;
+    }
+  }
+</style>
+
+<div class="privacy-page">
+  <div class="privacy-shell">
+    <header class="privacy-hero">
+      <div class="privacy-eyebrow">
+        FMUG Policy
+        <span class="privacy-badge">Draft</span>
+      </div>
+      <h1>Privacy Statement</h1>
+      <p class="privacy-intro">
+        This page is presented as a formal policy document. Operational details that are still being finalized remain clearly marked in the draft text below.
+      </p>
+      <p class="privacy-meta">Last updated: March 24, 2026</p>
+    </header>
+
+    <div class="privacy-article">
+      <%= render_markdown_content("privacy.md") %>
+    </div>
   </div>
 </div>

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -1,1 +1,106 @@
-This is a placeholder privacy statement.
+# Privacy Statement (DRAFT)
+
+This Privacy Statement is a draft and is not yet the final published version. Some operational details, including hosting and storage location, still need to be confirmed and will be updated before final publication.
+
+## Who we are
+
+FMUG operates this website and acts as the controller for the personal data described in this statement.
+
+For privacy questions, requests, or concerns, please contact:
+[chair@fmug.eu](mailto:chair@fmug.eu)
+
+## Personal data we collect
+
+Depending on how you use the FMUG website, we may process the following personal data:
+
+- Name, including first name and last name
+- Email address
+- Role within FMUG
+- Company affiliation, where provided
+- Whether a user has administrator access
+- Conference registration details, including attendance preference
+- Agenda preferences and any agenda notes submitted during registration
+- Dietary requirements and related notes you choose to provide
+- Invitation details, such as the invited first name and email address
+- Authentication and account access data, such as Google sign-in identifier data and one-time login or invitation token records
+- Technical session information needed to keep you signed in securely
+
+## How we use personal data
+
+We use personal data to:
+
+- Create and manage FMUG member accounts
+- Let members sign in, including by Google login or email magic link
+- Send invitations and login emails
+- Manage conference registrations
+- Record agenda preferences and attendance choices
+- Record dietary requirements where relevant to conference participation
+- Allow administrators to manage membership and conference participation
+- Maintain the security and operation of the website
+- Comply with applicable legal obligations, including GDPR
+
+## Legal bases
+
+We process personal data under GDPR on one or more of the following bases:
+
+- Performance of a contract or taking steps at your request before entering into one, for example when creating an account, signing in, or managing conference registration
+- Legitimate interests, including operating FMUG, organizing conferences, managing membership, and keeping the website secure
+- Compliance with legal obligations, where applicable
+- Consent, where this is specifically required
+
+## Emails and third parties
+
+FMUG sends transactional emails, such as invitations, login links, and registration confirmations, using Brevo.
+
+Google sign-in may also be used when enabled, in which case Google processes authentication data needed to sign you in.
+
+The members page currently uses `robohash.org` to generate test avatar images. This is temporary test functionality and is intended to be removed in due course.
+
+We do not sell personal data.
+
+## Cookies and sessions
+
+The website uses an essential session cookie to keep users signed in and to operate the authenticated parts of the website. This session cookie is currently configured to expire after 8 hours.
+
+At the time of this draft, no separate advertising or analytics tooling has been identified in the application code.
+
+## Data retention
+
+FMUG retains personal data only for as long as needed for the purposes described above.
+
+Current retention approach:
+
+- Inactive member accounts will be removed after 2 years of inactivity
+- Invitation and magic link records are time-limited and expire automatically after a short period
+- Some technical records may remain in backups or logs for a limited period where necessary for security, integrity, or recovery purposes
+
+This section is part of the draft and may be refined in the final version.
+
+## Storage and international transfers
+
+This Privacy Statement is a draft. The final version will specify where the website and database are hosted, where personal data is stored, and whether any international transfers take place.
+
+## Your GDPR rights
+
+Under GDPR, you may have the right to request:
+
+- Access to your personal data
+- Correction of inaccurate personal data
+- Deletion of your personal data
+- Restriction of processing
+- Objection to processing
+- Data portability, where applicable
+- Withdrawal of consent, where processing is based on consent
+- The right to lodge a complaint with a supervisory authority
+
+FMUG will respect applicable GDPR rights. If you want to exercise your rights, or if you have any privacy concerns, please contact [chair@fmug.eu](mailto:chair@fmug.eu).
+
+It is also possible to remove your own personal data from the database by deleting your own account through the website, where that functionality is available.
+
+## Security
+
+FMUG takes reasonable technical and organizational measures to protect personal data. Based on the current application configuration, this includes HTTPS enforcement in production, filtered logging for sensitive parameters such as email addresses and tokens, expiring login links, and access controls for administrative functions.
+
+## Changes to this statement
+
+This statement may be updated from time to time. Because this is currently a draft, further changes are expected before publication of the final version.


### PR DESCRIPTION
## Summary
- add a draft privacy statement based on the current application data flows and GDPR requirements
- include privacy contact details, retention guidance, GDPR rights, and draft placeholders for hosting/storage details
- redesign the privacy page with a more readable documentation-style layout
- add a visible last-updated date to the privacy page header

## Testing
- Not run (not requested)