### PR TITLE
Update public host configuration for OmniAuth callbacks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -486,4 +486,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   2.6.7
+  4.0.9


### PR DESCRIPTION
## Summary
- derive the app host, protocol, port, and path from `APP_URL`
- apply those defaults to Rails routes and Action Mailer URL generation
- set `OmniAuth.config.full_host` so OAuth callbacks use the correct public base URL, including subpaths

## Testing
- Not run (not requested)